### PR TITLE
Add: 投稿後詳細ページに遷移する処理を追加

### DIFF
--- a/src/components/molecules/PostedPageItems.tsx
+++ b/src/components/molecules/PostedPageItems.tsx
@@ -59,13 +59,15 @@ const PostedPageItems: FC<Props> = ({ ...props }) => {
           style={styles.touchableOpacity}
           onPress={() =>
             navigation.navigate("post", {
-              photo_id,
-              uid,
-              create_time,
-              url,
-              favoriteNumber,
-              latitude,
-              longitude,
+              imageData: {
+                photo_id,
+                uid,
+                create_time,
+                url,
+                favoriteNumber,
+                latitude,
+                longitude,
+              },
             })
           }
         >

--- a/src/components/molecules/TabMenu.tsx
+++ b/src/components/molecules/TabMenu.tsx
@@ -35,14 +35,16 @@ const TabMenu: FC<Props> = ({ navigation, photoDataList, favoriteItems }) => {
                 activeOpacity={0.8}
                 onPress={() =>
                   navigation.navigate("post", {
-                    photo_id: item.photo_id,
-                    uid: item.uid,
-                    create_time: item.create_time,
-                    url: item.url,
-                    favoriteNumber: item.favoriteNumber,
-                    latitude: item.latitude,
-                    longitude: item.longitude,
-                    photogenic_subject: item.photogenic_subject,
+                    imageData: {
+                      photo_id: item.photo_id,
+                      uid: item.uid,
+                      create_time: item.create_time,
+                      url: item.url,
+                      favoriteNumber: item.favoriteNumber,
+                      latitude: item.latitude,
+                      longitude: item.longitude,
+                      photogenic_subject: item.photogenic_subject,
+                    },
                   })
                 }
               >
@@ -72,14 +74,16 @@ const TabMenu: FC<Props> = ({ navigation, photoDataList, favoriteItems }) => {
                 activeOpacity={0.8}
                 onPress={() =>
                   navigation.navigate("post", {
-                    photo_id: item.photo_id,
-                    uid: item.uid,
-                    create_time: item.create_time,
-                    url: item.url,
-                    favoriteNumber: item.favoriteNumber,
-                    latitude: item.latitude,
-                    longitude: item.longitude,
-                    photogenic_subject: item.photogenic_subject,
+                    imageData: {
+                      photo_id: item.photo_id,
+                      uid: item.uid,
+                      create_time: item.create_time,
+                      url: item.url,
+                      favoriteNumber: item.favoriteNumber,
+                      latitude: item.latitude,
+                      longitude: item.longitude,
+                      photogenic_subject: item.photogenic_subject,
+                    },
                   })
                 }
               >

--- a/src/components/organisms/ImageList.tsx
+++ b/src/components/organisms/ImageList.tsx
@@ -42,13 +42,15 @@ const ImageList: FC<Props> = ({ ...props }) => {
               activeOpacity={0.8}
               onPress={() =>
                 navigation.navigate("post", {
-                  photo_id: item.photo_id,
-                  uid: item.uid,
-                  create_time: item.create_time,
-                  url: item.url,
-                  latitude: item.latitude,
-                  longitude: item.longitude,
-                  photogenic_subject: item.photogenic_subject,
+                  imageData: {
+                    photo_id: item.photo_id,
+                    uid: item.uid,
+                    create_time: item.create_time,
+                    url: item.url,
+                    latitude: item.latitude,
+                    longitude: item.longitude,
+                    photogenic_subject: item.photogenic_subject,
+                  },
                 })
               }
             >

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -63,6 +63,7 @@ const Post: FC<Props> = ({ ...props }) => {
           <TextInput
             style={styles.photgenicSubjectInput}
             placeholder={"被写体を入力（例 : 東京スカイツリー）"}
+            maxLength={25}
             onChangeText={(text) => setPhotogenicSubject(text)}
             autoCapitalize={"none"}
             keyboardType="default"

--- a/src/containers/molecules/DetailPostedPageItems.tsx
+++ b/src/containers/molecules/DetailPostedPageItems.tsx
@@ -62,7 +62,7 @@ const DetailPostedPageItemsContainer: FC<Props> = ({ ...props }) => {
       setIsFavoriteStatus(true);
 
       await accountFireStore.updateFavoriteList(photo_id);
-      await photoFireStore.IncrementFavoriteNumber(photo_id, favoriteNumber);
+      await photoFireStore.IncrementFavoriteNumber(photo_id);
       await photoFireStore.getFavoriteNumber(photo_id).then((res) => {
         setFavoriteNumber(res);
       });
@@ -88,7 +88,7 @@ const DetailPostedPageItemsContainer: FC<Props> = ({ ...props }) => {
       }
     } else {
       await accountFireStore.deleteFavoriteItem(photo_id);
-      await photoFireStore.DecrementFavoriteNumber(photo_id, favoriteNumber);
+      await photoFireStore.DecrementFavoriteNumber(photo_id);
       await photoFireStore.getFavoriteNumber(photo_id).then((res) => {
         setFavoriteNumber(res);
       });

--- a/src/containers/organisms/Post.tsx
+++ b/src/containers/organisms/Post.tsx
@@ -234,7 +234,12 @@ const PostContainer: FC<Props> = ({ ...props }) => {
   useEffect(() => {
     // マウント時 & uid, uri, 被写体の名称、位置情報が異なる時に実行
     const onPress = async () => {
-      const hasError = checkHasError(uid, uri, photogenicSubject, location);
+      const hasError = await checkHasError(
+        uid,
+        uri,
+        photogenicSubject,
+        location
+      );
       if (hasError) return;
       const photoData = await uploadPostImage(
         uid,
@@ -246,7 +251,10 @@ const PostContainer: FC<Props> = ({ ...props }) => {
       const selectedPhotoData = { allPhotoDataList, myPhotoDataList };
       dispatchPhotoData(dispatch, selectedPhotoData, photoData);
       console.log(photoData.photo_id);
-      navigation.navigate("postedImageDetail", photoData);
+      navigation.navigate("postedImageDetail", {
+        imageData: photoData,
+        shouldHeaderLeftBeCross: true,
+      });
     };
     navigation.setOptions({
       headerRight: () => (

--- a/src/containers/organisms/Post.tsx
+++ b/src/containers/organisms/Post.tsx
@@ -245,8 +245,7 @@ const PostContainer: FC<Props> = ({ ...props }) => {
       if (!photoData) return;
       const selectedPhotoData = { allPhotoDataList, myPhotoDataList };
       dispatchPhotoData(dispatch, selectedPhotoData, photoData);
-      // navigation.navigate("postedImageDetail", {
-      // })
+      navigation.navigate("postedImageDetail", photoData);
     };
     navigation.setOptions({
       headerRight: () => (

--- a/src/containers/organisms/Post.tsx
+++ b/src/containers/organisms/Post.tsx
@@ -222,8 +222,8 @@ const PostContainer: FC<Props> = ({ ...props }) => {
     (state: RootState) => state.myPhotoReducer.photoDataList
   );
 
+  // 撮影場所を初期化
   useEffect(() => {
-    // マウント時 & uriが異なる時に実行
     if (type === "camera") {
       getLocationAddressAsync(setLocation);
     } else {
@@ -231,8 +231,8 @@ const PostContainer: FC<Props> = ({ ...props }) => {
     }
   }, [uri]);
 
+  // 投稿ボタン押下時の処理を定義
   useEffect(() => {
-    // マウント時 & uid, uri, 被写体の名称、位置情報が異なる時に実行
     const onPress = async () => {
       const hasError = await checkHasError(
         uid,
@@ -250,7 +250,6 @@ const PostContainer: FC<Props> = ({ ...props }) => {
       if (!photoData) return;
       const selectedPhotoData = { allPhotoDataList, myPhotoDataList };
       dispatchPhotoData(dispatch, selectedPhotoData, photoData);
-      console.log(photoData.photo_id);
       navigation.navigate("postedImageDetail", {
         imageData: photoData,
         shouldHeaderLeftBeCross: true,
@@ -267,8 +266,8 @@ const PostContainer: FC<Props> = ({ ...props }) => {
     });
   }, [uid, uri, photogenicSubject, location]);
 
+  // 閉じるボタン押下時の処理
   useEffect(() => {
-    // マウント時 & typeが異なる時に実行
     dispatch(setShouldDisplayBottomNav(false));
     navigation.setOptions({
       headerLeft: () => (

--- a/src/containers/organisms/Post.tsx
+++ b/src/containers/organisms/Post.tsx
@@ -245,6 +245,7 @@ const PostContainer: FC<Props> = ({ ...props }) => {
       if (!photoData) return;
       const selectedPhotoData = { allPhotoDataList, myPhotoDataList };
       dispatchPhotoData(dispatch, selectedPhotoData, photoData);
+      console.log(photoData.photo_id);
       navigation.navigate("postedImageDetail", photoData);
     };
     navigation.setOptions({

--- a/src/containers/organisms/PostedImageDetail.tsx
+++ b/src/containers/organisms/PostedImageDetail.tsx
@@ -2,12 +2,19 @@ import React, { FC, useEffect, useRef, useCallback } from "react";
 import { TextInput } from "react-native";
 import { RootState } from "../../reducers/index";
 import { useSelector, useDispatch } from "react-redux";
+import firebase from "firebase";
+import { RouteProp } from "@react-navigation/core/lib/typescript/src/types";
 import { commentFireStore } from "../../firebase/commentFireStore";
 import { setCommentDataList, setIsInputForm } from "../../actions/postedData";
 import PostedImageDetail from "../../components/organisms/PostedImageDetail";
 
+type routeObj = {
+  imageData: firebase.firestore.DocumentData;
+  shouldHeaderLeftBeCross?: boolean;
+};
+
 type Props = {
-  route: any;
+  route: RouteProp<Record<string, routeObj>, string>;
 };
 
 const PostedImageDetailContainer: FC<Props> = ({ route }) => {
@@ -19,7 +26,7 @@ const PostedImageDetailContainer: FC<Props> = ({ route }) => {
     latitude,
     longitude,
     photogenic_subject,
-  } = route.params;
+  } = route.params.imageData;
 
   const selrctCommentDataList = (state: RootState) =>
     state.postedDataReducer.commentDataList;

--- a/src/containers/organisms/PostedImageDetail.tsx
+++ b/src/containers/organisms/PostedImageDetail.tsx
@@ -1,12 +1,19 @@
 import React, { FC, useEffect, useRef, useCallback } from "react";
-import { TextInput } from "react-native";
+import { TextInput, TouchableOpacity } from "react-native";
 import { RootState } from "../../reducers/index";
 import { useSelector, useDispatch } from "react-redux";
 import firebase from "firebase";
-import { RouteProp } from "@react-navigation/core/lib/typescript/src/types";
+import {
+  NavigationProp,
+  RouteProp,
+} from "@react-navigation/core/lib/typescript/src/types";
 import { commentFireStore } from "../../firebase/commentFireStore";
 import { setCommentDataList, setIsInputForm } from "../../actions/postedData";
+import { setShouldDisplayBottomNav } from "../../actions/bottomNav";
+import { setShouldNavigateMap } from "../../actions/mapNavigate";
 import PostedImageDetail from "../../components/organisms/PostedImageDetail";
+import FontAwesome from "react-native-vector-icons/FontAwesome";
+import { styles } from "../../styles/post";
 
 type routeObj = {
   imageData: firebase.firestore.DocumentData;
@@ -15,9 +22,10 @@ type routeObj = {
 
 type Props = {
   route: RouteProp<Record<string, routeObj>, string>;
+  navigation: NavigationProp<Record<string, object>>;
 };
 
-const PostedImageDetailContainer: FC<Props> = ({ route }) => {
+const PostedImageDetailContainer: FC<Props> = ({ route, navigation }) => {
   const {
     photo_id,
     uid,
@@ -27,6 +35,7 @@ const PostedImageDetailContainer: FC<Props> = ({ route }) => {
     longitude,
     photogenic_subject,
   } = route.params.imageData;
+  const shouldHeaderLeftBeCross = route.params.shouldHeaderLeftBeCross;
 
   const selrctCommentDataList = (state: RootState) =>
     state.postedDataReducer.commentDataList;
@@ -34,6 +43,22 @@ const PostedImageDetailContainer: FC<Props> = ({ route }) => {
   const commentDataList = useSelector(selrctCommentDataList);
   const textInputRef = useRef<null | TextInput>(null);
   const dispatch = useDispatch();
+
+  // 投稿画面から遷移した場合、ヘッダーのボタンを書き換える
+  useEffect(() => {
+    if (shouldHeaderLeftBeCross === undefined) return;
+    const onPress = () => {
+      dispatch(setShouldDisplayBottomNav(true));
+      dispatch(setShouldNavigateMap(true));
+    };
+    navigation.setOptions({
+      headerLeft: () => (
+        <TouchableOpacity activeOpacity={0.6} onPress={() => onPress()}>
+          <FontAwesome name="times" style={styles.crossButton} />
+        </TouchableOpacity>
+      ),
+    });
+  }, []);
 
   // コメント取得
   useEffect(() => {

--- a/src/screens/PostScreen.tsx
+++ b/src/screens/PostScreen.tsx
@@ -25,7 +25,6 @@ const PostScreen: FC = () => {
         component={PostedImageDetail}
         options={{
           title: "投稿",
-          headerBackTitleVisible: false,
           headerTintColor: baseColor.text,
           headerStyle: {
             backgroundColor: baseColor.darkNavy,

--- a/src/screens/PostScreen.tsx
+++ b/src/screens/PostScreen.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import { createStackNavigator } from "@react-navigation/stack";
 import Post from "../containers/organisms/Post";
-import Home from "../containers/organisms/Home";
+import PostedImageDetail from "../containers/organisms/PostedImageDetail";
 import { baseColor } from "../styles/thema/colors";
 
 const PostScreen: FC = () => {
@@ -13,6 +13,18 @@ const PostScreen: FC = () => {
         component={Post}
         options={{
           title: "投稿する",
+          headerBackTitleVisible: false,
+          headerTintColor: baseColor.text,
+          headerStyle: {
+            backgroundColor: baseColor.darkNavy,
+          },
+        }}
+      />
+      <Stack.Screen
+        name="postedImageDetail"
+        component={PostedImageDetail}
+        options={{
+          title: "投稿",
           headerBackTitleVisible: false,
           headerTintColor: baseColor.text,
           headerStyle: {


### PR DESCRIPTION
## 目的
- 投稿機能を完成させる

## 達成条件
- [x] 投稿画面の作成
- [x] 画像をstorageに保存
- [x] 投稿データをfirestoreに保存
- [x] 投稿データをReduxに追加
- [x] 投稿後に詳細ページに遷移
- [ ] 投稿時、キャンセルボタン押下時に「カメラ/アルバムに戻る」「ホーム画面に戻る」の二項目のアクションシートを用意する処理を追加
- [ ] アルバムボタン選択時、その写真に位置情報が埋め込まれていればそれを参照する
- [ ] 位置情報入力欄押下時に、マップ画面に遷移してピンを立てた箇所を位置情報として取得できるようにする
- [ ] 画像圧縮処理
- [ ] トリミング処理
- [ ] デザインの修正

## 実装の概要
- 投稿後、画像詳細ページに遷移する処理を追加
- 画像詳細ページ遷移時、ヘッダーに閉じるボタンを用意
  - 閉じるボタン押下時、ホーム(マップ画面)に遷移させた

## 今後のタスク
- [ ] 投稿時、キャンセルボタン押下時に「カメラ/アルバムに戻る」「ホーム画面に戻る」の二項目のアクションシートを用意する処理を追加
- [ ] アルバムボタン選択時、その写真に位置情報が埋め込まれていればそれを参照する
- [ ] 位置情報入力欄押下時に、マップ画面に遷移してピンを立てた箇所を位置情報として取得できるようにする
- [ ] 画像圧縮処理
- [ ] トリミング処理
- [ ] デザインの修正