### PR TITLE
Add: 通知画面から投稿詳細画面に遷移できるようにした

### DIFF
--- a/src/components/molecules/NotificationItem.tsx
+++ b/src/components/molecules/NotificationItem.tsx
@@ -1,0 +1,84 @@
+import React, { FC } from "react";
+import { View, TouchableOpacity, ActivityIndicator } from "react-native";
+import { Image } from "react-native-elements";
+import { StyleSheet } from "react-native";
+import { deviceWidth } from "../../utilities/dimensions";
+import NotificationText from "../atoms/NotificationText";
+import { callingAlert } from "../../utilities/alert";
+
+type Props = {
+  navigation: any;
+  item: firebase.firestore.DocumentData;
+  data: firebase.firestore.DocumentData | undefined;
+};
+
+const NotificationItem: FC<Props> = ({ navigation, item, data }) => {
+  return (
+    <>
+      <TouchableOpacity
+        activeOpacity={0.8}
+        onPress={() =>
+          !!data
+            ? navigation.navigate("post", {
+                imageData: {
+                  photo_id: data.photo_id,
+                  uid: data.uid,
+                  create_time: data.create_time,
+                  url: data.url,
+                  favoriteNumber: data.favoriteNumber,
+                  latitude: data.latitude,
+                  longitude: data.longitude,
+                },
+              })
+            : callingAlert("投稿が見つかりませんでした。")
+        }
+      >
+        <View style={styles.wrapper}>
+          <Image
+            style={styles.userImage}
+            source={{
+              uri: item.opponent_url,
+            }}
+            PlaceholderContent={<ActivityIndicator />}
+          />
+          <NotificationText
+            opponent_name={item.opponent_name}
+            content={item.content}
+            create_time={item.create_time}
+          />
+          <Image
+            style={styles.photoImage}
+            source={{
+              uri: item.photo_url,
+            }}
+            PlaceholderContent={<ActivityIndicator />}
+          />
+        </View>
+      </TouchableOpacity>
+      <View style={styles.border} />
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flexDirection: "row",
+    padding: 15,
+  },
+  userImage: {
+    width: 52,
+    height: 52,
+    borderRadius: 180,
+  },
+  photoImage: {
+    width: 72,
+    height: 72,
+  },
+  border: {
+    width: deviceWidth,
+    borderBottomWidth: 0.5,
+    borderBottomColor: "#808080",
+  },
+});
+
+export default NotificationItem;

--- a/src/components/molecules/NotificationItem.tsx
+++ b/src/components/molecules/NotificationItem.tsx
@@ -28,6 +28,7 @@ const NotificationItem: FC<Props> = ({ navigation, item, data }) => {
                   favoriteNumber: data.favoriteNumber,
                   latitude: data.latitude,
                   longitude: data.longitude,
+                  photogenic_subject: data.photogenic_subject,
                 },
               })
             : callingAlert("投稿が見つかりませんでした。")

--- a/src/components/organisms/BottomNav.tsx
+++ b/src/components/organisms/BottomNav.tsx
@@ -103,9 +103,9 @@ const BottomNav: FC<Props> = ({ ...props }) => {
 const iPhone11Width = 414;
 const displayWidth = Dimensions.get("window").width;
 const displayHeight = Dimensions.get("window").height;
-const itemsFloatingRatio = 0.00966;
+const itemsFloatingRatio = 4 / iPhone11Width;
 const viewboxRatio = 4.4588; // viewbox.width / viewbox.height
-const footerBgBtmRatio = -19 / iPhone11Width;
+const footerBgBtmRatio = -19.5 / iPhone11Width;
 const footerBgBtm = displayWidth * footerBgBtmRatio;
 
 const styles = StyleSheet.create({

--- a/src/components/organisms/Notification.tsx
+++ b/src/components/organisms/Notification.tsx
@@ -1,15 +1,8 @@
-import React, { FC, Fragment } from "react";
-import {
-  View,
-  ScrollView,
-  TouchableOpacity,
-  ActivityIndicator,
-} from "react-native";
-import { Image } from "react-native-elements";
+import React, { FC } from "react";
+import { View, ScrollView } from "react-native";
 import { StyleSheet } from "react-native";
-import { deviceWidth } from "../../utilities/dimensions";
 import { baseColor } from "../../styles/thema/colors";
-import NotificationText from "../atoms/NotificationText";
+import NotificationItem from "../../containers/molecules/NotificationItem";
 import NoNotificationTex from "../atoms/NoNotificationText";
 
 type Props = {
@@ -30,40 +23,11 @@ const Notification: FC<Props> = ({
         <ScrollView style={styles.container}>
           <View style={[styles.box, { paddingBottom: bottomHeight }]}>
             {notificationDataList.map((item, index) => (
-              <Fragment key={index}>
-                <TouchableOpacity
-                  activeOpacity={0.8}
-                  onPress={() =>
-                    navigation.navigate("otherUser", {
-                      uid: item.opponent_uid,
-                      name: item.opponent_name,
-                    })
-                  }
-                >
-                  <View style={styles.wrapper}>
-                    <Image
-                      style={styles.userImage}
-                      source={{
-                        uri: item.opponent_url,
-                      }}
-                      PlaceholderContent={<ActivityIndicator />}
-                    />
-                    <NotificationText
-                      opponent_name={item.opponent_name}
-                      content={item.content}
-                      create_time={item.create_time}
-                    />
-                    <Image
-                      style={styles.photoImage}
-                      source={{
-                        uri: item.photo_url,
-                      }}
-                      PlaceholderContent={<ActivityIndicator />}
-                    />
-                  </View>
-                </TouchableOpacity>
-                <View style={styles.border} />
-              </Fragment>
+              <NotificationItem
+                key={index}
+                navigation={navigation}
+                item={item}
+              />
             ))}
           </View>
         </ScrollView>
@@ -82,24 +46,6 @@ const styles = StyleSheet.create({
   box: {
     alignItems: "center",
     paddingBottom: 104,
-  },
-  wrapper: {
-    flexDirection: "row",
-    padding: 15,
-  },
-  userImage: {
-    width: 52,
-    height: 52,
-    borderRadius: 180,
-  },
-  photoImage: {
-    width: 72,
-    height: 72,
-  },
-  border: {
-    width: deviceWidth,
-    borderBottomWidth: 0.5,
-    borderBottomColor: "#808080",
   },
 });
 

--- a/src/components/organisms/PostedImageDetail.tsx
+++ b/src/components/organisms/PostedImageDetail.tsx
@@ -5,6 +5,7 @@ import {
   ActivityIndicator,
   TextInput,
   StyleSheet,
+  Dimensions,
 } from "react-native";
 import { Image } from "react-native-elements";
 import { Timestamp } from "@google-cloud/firestore";
@@ -26,6 +27,7 @@ type Props = {
   uid: string;
   create_time: Timestamp;
   url: string;
+  aspectRatio: number;
   latitude: number;
   longitude: number;
   photogenic_subject: string;
@@ -42,6 +44,7 @@ const PostedImageDetail: FC<Props> = ({ ...props }) => {
     uid,
     create_time,
     url,
+    aspectRatio,
     latitude,
     longitude,
     photogenic_subject,
@@ -50,6 +53,8 @@ const PostedImageDetail: FC<Props> = ({ ...props }) => {
     focusOnInput,
     bottomHeight,
   } = props;
+
+  const displayWidth = Dimensions.get("window").width;
 
   return (
     <View style={[styles.container, { paddingBottom: bottomHeight }]}>
@@ -61,7 +66,10 @@ const PostedImageDetail: FC<Props> = ({ ...props }) => {
             photogenic_subject={photogenic_subject}
           />
           <Image
-            style={styles.image}
+            style={{
+              width: displayWidth,
+              height: displayWidth * aspectRatio,
+            }}
             source={{
               uri: url,
             }}
@@ -106,10 +114,6 @@ const styles = StyleSheet.create({
   allWrap: {
     width: wp("100%"),
     paddingBottom: 101,
-  },
-  image: {
-    width: wp("100%"),
-    height: hp("25%"),
   },
 });
 

--- a/src/containers/molecules/BottomNavTouchableOpacity.tsx
+++ b/src/containers/molecules/BottomNavTouchableOpacity.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { Dispatch } from "redux";
 import type { BottomTabBarProps } from "@react-navigation/bottom-tabs/lib/typescript/src/types";
 import type { Route } from "@react-navigation/routers/lib/typescript/src/types";
 import { RootState } from "../../reducers/index";
@@ -13,6 +14,22 @@ type Props = {
   descriptors: BottomTabBarProps["descriptors"];
   navigation: BottomTabBarProps["navigation"];
   index: number;
+};
+
+const navigateMap = (
+  index: number,
+  navigation: BottomTabBarProps["navigation"],
+  route: Route<string>,
+  dispatch: Dispatch
+) => {
+  const mapIndex = 0;
+  if (index !== mapIndex) return;
+  const shouldNavigateMap = useSelector(
+    (state: RootState) => state.mapNavigateReducer.shouldNavigateMap
+  );
+  if (!shouldNavigateMap) return;
+  navigation.navigate(route["name"]);
+  dispatch(setShouldNavigateMap(false));
 };
 
 const BottomNavTouchableOpacityContainer: FC<Props> = ({ ...props }) => {
@@ -48,16 +65,7 @@ const BottomNavTouchableOpacityContainer: FC<Props> = ({ ...props }) => {
     });
   };
 
-  const navigateMap = (() => {
-    const mapIndex = 0;
-    if (index !== mapIndex) return;
-    const shouldNavigateMap = useSelector(
-      (state: RootState) => state.mapNavigateReducer.shouldNavigateMap
-    );
-    if (!shouldNavigateMap) return;
-    navigation.navigate(route["name"]);
-    dispatch(setShouldNavigateMap(false));
-  })();
+  navigateMap(index, navigation, route, dispatch);
 
   return (
     <BottomNavTouchableOpacity

--- a/src/containers/molecules/NotificationItem.tsx
+++ b/src/containers/molecules/NotificationItem.tsx
@@ -1,0 +1,33 @@
+import React, { FC, useState, useEffect } from "react";
+import { RootState } from "../../reducers/index";
+import { setNotificationDataList } from "../../actions/notification";
+import { db } from "../../firebase/firebase";
+import NotificationItem from "../../components/molecules/NotificationItem";
+
+type Props = {
+  navigation: any;
+  item: firebase.firestore.DocumentData;
+};
+const NotificationItemContainer: FC<Props> = ({ navigation, item }) => {
+  const [data, setData] = useState<firebase.firestore.DocumentData>();
+  useEffect(() => {
+    db.collection("photos")
+      .where("url", "==", item.photo_url)
+      .get()
+      .then((querySnapshot) => {
+        if (querySnapshot.size > 1) {
+          console.warn("一つのURLから複数の投稿が検出されました");
+        }
+        querySnapshot.forEach((doc) => {
+          setData(doc.data());
+        });
+      })
+      .catch((error) => {
+        console.warn(error);
+      });
+  }, []);
+
+  return <NotificationItem navigation={navigation} item={item} data={data} />;
+};
+
+export default NotificationItemContainer;

--- a/src/containers/organisms/Notification.tsx
+++ b/src/containers/organisms/Notification.tsx
@@ -35,6 +35,7 @@ const ContainerNotification: FC<Props> = ({ navigation }) => {
           const product = change.doc.data({ serverTimestamps: "estimate" });
           const changeType = change.type;
           setTemporaryArray(temporaryArray.slice());
+
           switch (changeType) {
             case "added":
               temporaryArray.unshift(product);

--- a/src/containers/organisms/PostedImageDetail.tsx
+++ b/src/containers/organisms/PostedImageDetail.tsx
@@ -1,5 +1,5 @@
-import React, { FC, useEffect, useRef } from "react";
-import { TextInput, TouchableOpacity, StyleSheet } from "react-native";
+import React, { FC, useState, useEffect, useRef } from "react";
+import { TextInput, TouchableOpacity, Image, StyleSheet } from "react-native";
 import { RootState } from "../../reducers/index";
 import { useSelector, useDispatch } from "react-redux";
 import { StackNavigationProp } from "@react-navigation/stack";
@@ -29,6 +29,21 @@ type Props = {
   navigation: StackNavigationProp<Record<string, object>>;
 };
 
+const assignImageAspectRatio = (
+  uri: string,
+  set: React.Dispatch<React.SetStateAction<number>>
+) => {
+  Image.getSize(
+    uri,
+    (width, height) => {
+      set(height / width);
+    },
+    (error) => {
+      console.log(error);
+    }
+  );
+};
+
 const PostedImageDetailContainer: FC<Props> = ({ route, navigation }) => {
   const {
     photo_id,
@@ -49,6 +64,7 @@ const PostedImageDetailContainer: FC<Props> = ({ route, navigation }) => {
   const commentDataList = useSelector(selectCommentDataList);
   const bottomHeight = useSelector(selectBottomHeight);
   const textInputRef = useRef<TextInput>(null);
+  const [aspectRatio, setAspectRatio] = useState<number>(0);
   const dispatch = useDispatch();
 
   // 投稿画面から遷移した場合、ヘッダーのボタンを書き換える
@@ -91,6 +107,9 @@ const PostedImageDetailContainer: FC<Props> = ({ route, navigation }) => {
     dispatch(setIsInputForm(true));
   };
 
+  // 画像のwidthとheightを取得
+  assignImageAspectRatio(url, setAspectRatio);
+
   return (
     <PostedImageDetail
       navigation={navigation}
@@ -98,6 +117,7 @@ const PostedImageDetailContainer: FC<Props> = ({ route, navigation }) => {
       uid={uid}
       create_time={create_time}
       url={url}
+      aspectRatio={aspectRatio}
       latitude={latitude}
       longitude={longitude}
       photogenic_subject={photogenic_subject}

--- a/src/screens/NotificationScreen.tsx
+++ b/src/screens/NotificationScreen.tsx
@@ -7,7 +7,6 @@ import PostedImageDetail from "../containers/organisms/PostedImageDetail";
 
 export type NotificationScreenStackParamList = {
   notification: undefined;
-  otherUser: { name: string; uid: string };
   post: {
     imageData: {
       photo_id: string;

--- a/src/screens/NotificationScreen.tsx
+++ b/src/screens/NotificationScreen.tsx
@@ -1,12 +1,25 @@
 import React, { FC } from "react";
 import { createStackNavigator } from "@react-navigation/stack";
+import { Timestamp } from "@google-cloud/firestore";
 import { baseColor } from "../styles/thema/colors";
 import Notification from "../containers/organisms/Notification";
-import OtherUser from "../containers/organisms/OtherUser";
+import PostedImageDetail from "../containers/organisms/PostedImageDetail";
 
 export type NotificationScreenStackParamList = {
   notification: undefined;
   otherUser: { name: string; uid: string };
+  post: {
+    imageData: {
+      photo_id: string;
+      uid: string;
+      create_time: Timestamp;
+      url: string;
+      latitude: number;
+      longitude: number;
+      photogenic_subject: string;
+    };
+    shouldHeaderLeftBeCross?: boolean;
+  };
 };
 
 const NotificationScreen: FC = () => {
@@ -25,10 +38,10 @@ const NotificationScreen: FC = () => {
         }}
       />
       <Stack.Screen
-        name="otherUser"
-        component={OtherUser}
+        name="post"
+        component={PostedImageDetail}
         options={({ route }) => ({
-          title: `${route.params.name}`,
+          title: route.params.imageData.photogenic_subject,
           headerBackTitleVisible: false,
           headerTintColor: baseColor.text,
           headerStyle: {


### PR DESCRIPTION
## 実装の概要
- `Notification.tsx`で`map`で回していた部分をコンテナとコンポーネントに分け、その中で`photo_url`を用いてfirestoreの`photos`コレクションからデータを引っ張ってくる処理を記述した
- 投稿が引っ張ってこれなかった場合は「投稿が見つかりませんでした」とアラート表示

## 今後のタスク
- 画像圧縮処理