### PR TITLE
写真撮影位置をpinで指定

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -9,6 +9,7 @@ import { setShouldNavigateMap } from "./mapNavigate";
 import { setFavoriteItems } from "./favorite";
 import { setNotificationDataList } from "./notification";
 import { setCommentDataList, setIsInputForm } from "./postedData";
+import { setPostPhoto } from "./postPhoto";
 import {
   setUserData,
   upDateUserName,
@@ -43,6 +44,7 @@ export enum ActionTypes {
   SET_SHOULD_NAVIGATE = "SET_SHOULD_NAVIGATE",
   SET_FAVORITE_ITEMS = "SET_FAVORITE_ITEMS",
   SET_NOTIFICATION_DATA_LIST = "SET_NOTIFICATION_DATA_LIST",
+  SET_POST_PHOTO = "SET_POST_PHOTO",
 }
 
 export type UnionedAction =
@@ -67,4 +69,5 @@ export type UnionedAction =
   | ReturnType<typeof setPostData>
   | ReturnType<typeof setShouldNavigateMap>
   | ReturnType<typeof setFavoriteItems>
-  | ReturnType<typeof setNotificationDataList>;
+  | ReturnType<typeof setNotificationDataList>
+  | ReturnType<typeof setPostPhoto>;

--- a/src/actions/postPhoto.ts
+++ b/src/actions/postPhoto.ts
@@ -1,0 +1,11 @@
+import { ActionTypes } from "./index";
+
+//写真一覧の情報をセット
+export const setPostPhoto = (latitude: number, longitude: number) =>
+  ({
+    type: ActionTypes.SET_POST_PHOTO,
+    payload: {
+      latitude,
+      longitude,
+    },
+  } as const);

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -29,6 +29,7 @@ type Props = {
   photogenicSubject: string;
   setPhotogenicSubject: React.Dispatch<React.SetStateAction<string>>;
   onPressLocationRow: () => void;
+  navigation: any;
 };
 
 const Post: FC<Props> = ({ ...props }) => {
@@ -42,6 +43,7 @@ const Post: FC<Props> = ({ ...props }) => {
     photogenicSubject,
     setPhotogenicSubject,
     onPressLocationRow,
+    navigation,
   } = props;
 
   const width = deviceWidth;
@@ -90,7 +92,7 @@ const Post: FC<Props> = ({ ...props }) => {
           <TouchableOpacity
             activeOpacity={1}
             style={styles.locationTextWrap}
-            onPress={() => onPressLocationRow()}
+            onPress={() => navigation.navigate("postedMap")}
           >
             <Text style={[styles.locationText, addressColorStyle]}>
               {address}

--- a/src/components/organisms/PostedMap.tsx
+++ b/src/components/organisms/PostedMap.tsx
@@ -1,0 +1,111 @@
+import React, { FC, useState, useRef } from "react";
+import {
+  AppRegistry,
+  StyleSheet,
+  Text,
+  View,
+  ScrollView,
+  Animated,
+  Image,
+  Dimensions,
+  TouchableOpacity,
+  Platform,
+  ImageBackground,
+} from "react-native";
+import { Container } from "native-base";
+import { PROVIDER_GOOGLE, Marker } from "react-native-maps";
+import MapView from "react-native-map-clustering";
+import UserSwitchButtonView from "./UserSwitchButton";
+import LocationButtonView from "./PresentLocationButton";
+import OriginMarker from "../atoms/OriginMarker";
+import { useEffect } from "react";
+import { useTheme } from "@react-navigation/native";
+import { photoFireStore } from "../../firebase/photoFireStore";
+import { accountFireStore } from "../../firebase/accountFireStore";
+import { baseColor } from "../../styles/thema/colors";
+import { useSelector, useDispatch } from "react-redux";
+import { setPostPhoto } from "../../actions/postPhoto";
+import { RootState } from "../../reducers/index";
+
+type Region = {
+  latitude: number;
+  longitude: number;
+  latitudeDelta: number;
+  longitudeDelta: number;
+};
+
+type Props = {
+  navigation: any;
+  region: Region;
+};
+
+const PostMap: FC<Props> = ({ ...props }) => {
+  const dispatch = useDispatch();
+  const { navigation, region } = props;
+  let _map;
+  _map = React.useRef(null);
+  useEffect(() => {
+    dispatch(setPostPhoto(region.latitude, region.longitude));
+    _map.current.animateToRegion(region);
+  });
+
+  return (
+    <Container style={styles.box}>
+      <MapView
+        ref={_map}
+        style={{ ...StyleSheet.absoluteFillObject }}
+        provider={PROVIDER_GOOGLE}
+        showsUserLocation
+        initialRegion={region}
+      >
+        <Marker
+          draggable
+          coordinate={region}
+          image={require("../../../assets/pin02.png")}
+          onDragEnd={(e) =>
+            dispatch(
+              setPostPhoto(
+                e.nativeEvent.coordinate.latitude,
+                e.nativeEvent.coordinate.longitude
+              )
+            )
+          }
+        />
+      </MapView>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() => {
+          navigation.goBack();
+        }}
+      >
+        <Text style={styles.buttonText}>ここで決まり</Text>
+      </TouchableOpacity>
+    </Container>
+  );
+};
+
+const styles = StyleSheet.create({
+  box: {
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  button: {
+    position: "absolute",
+    bottom: 60,
+    width: 300,
+    height: 60,
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
+    borderTopLeftRadius: 15,
+    borderTopRightRadius: 15,
+    borderBottomLeftRadius: 15,
+    borderBottomRightRadius: 15,
+    backgroundColor: "#f00",
+  },
+  buttonText: {
+    fontSize: 20,
+    color: "#fff",
+  },
+});
+export default PostMap;

--- a/src/containers/organisms/Post.tsx
+++ b/src/containers/organisms/Post.tsx
@@ -353,6 +353,7 @@ const PostContainer: FC<Props> = ({ ...props }) => {
         photogenicSubject={photogenicSubject}
         setPhotogenicSubject={setPhotogenicSubject}
         onPressLocationRow={() => {}}
+        navigation={navigation}
       />
       <Spinner
         visible={isLoading}

--- a/src/containers/organisms/PostedMap.tsx
+++ b/src/containers/organisms/PostedMap.tsx
@@ -1,0 +1,52 @@
+import React, { FC, useEffect, useState } from "react";
+import PostMap from "../../components/organisms/PostedMap";
+import * as Permissions from "expo-permissions";
+import * as Location from "expo-location";
+import { photoFireStore } from "../../firebase/photoFireStore";
+import { useSelector, useDispatch } from "react-redux";
+import { setAllPhotoListData } from "../../actions/allPhoto";
+import { RootState } from "../../reducers/index";
+
+type Region = {
+  latitude: number;
+  longitude: number;
+  latitudeDelta: number;
+  longitudeDelta: number;
+};
+
+type Props = {
+  navigation: any;
+};
+
+const PostedMap: FC<Props> = ({ ...props }) => {
+  const { navigation } = props;
+  const dispatch = useDispatch();
+  const [region, setRegion] = useState<Region>({
+    latitude: 35.6340873,
+    longitude: 139.525187,
+    latitudeDelta: 30,
+    longitudeDelta: 30,
+  });
+
+  useEffect(() => {
+    const fetch = async () => {
+      try {
+        await Permissions.askAsync(Permissions.LOCATION);
+        const location = await Location.getCurrentPositionAsync({});
+        setRegion({
+          latitude: location.coords.latitude,
+          longitude: location.coords.longitude,
+          latitudeDelta: 0.1,
+          longitudeDelta: 0.1,
+        });
+      } catch (error) {
+        // to do
+      }
+    };
+    fetch();
+  }, []);
+
+  return <PostMap navigation={navigation} region={region} />;
+};
+
+export default PostedMap;

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -11,6 +11,7 @@ import { postReducer } from "./postReducer";
 import { mapNavigateReducer } from "./mapNavigateReducer";
 import { favoriteReducer } from "./favoriteReducer";
 import { notificationReducer } from "./notificationReducer";
+import { PostPhotoReducer } from "./postPhotoReducer";
 
 export const rootReducer = combineReducers({
   authReducer,
@@ -24,6 +25,7 @@ export const rootReducer = combineReducers({
   postReducer,
   mapNavigateReducer,
   favoriteReducer,
+  PostPhotoReducer,
   notificationReducer,
 });
 

--- a/src/reducers/postPhotoReducer.ts
+++ b/src/reducers/postPhotoReducer.ts
@@ -1,0 +1,31 @@
+import { Reducer } from "redux";
+import { ActionTypes, UnionedAction } from "../actions/index";
+
+export type State = {
+  latitude: number;
+  longitude: number;
+};
+
+type PostPhotoReducer = Reducer<State, UnionedAction>;
+
+const initialState: State = {
+  latitude: 0,
+  longitude: 0,
+};
+
+export const PostPhotoReducer: PostPhotoReducer = (
+  state = initialState,
+  action: UnionedAction
+): State => {
+  switch (action.type) {
+    case ActionTypes.SET_POST_PHOTO:
+      return {
+        ...state,
+        latitude: action.payload.latitude,
+        longitude: action.payload.longitude,
+      };
+    default: {
+      return state;
+    }
+  }
+};

--- a/src/screens/PostScreen.tsx
+++ b/src/screens/PostScreen.tsx
@@ -4,6 +4,7 @@ import { baseColor } from "../styles/thema/colors";
 import { Timestamp } from "@google-cloud/firestore";
 import Post from "../containers/organisms/Post";
 import PostedImageDetail from "../containers/organisms/PostedImageDetail";
+import PostedMap from "../containers/organisms/PostedMap";
 
 export type PostScreenStackParamList = {
   post: undefined;
@@ -47,6 +48,17 @@ const PostScreen: FC = () => {
             backgroundColor: baseColor.darkNavy,
           },
         })}
+      />
+      <Stack.Screen
+        name="postedMap"
+        component={PostedMap}
+        options={{
+          title: "撮影場所投稿",
+          headerTintColor: baseColor.text,
+          headerStyle: {
+            backgroundColor: baseColor.darkNavy,
+          },
+        }}
       />
     </Stack.Navigator>
   );


### PR DESCRIPTION
撮影位置をピンで指定できる様に変更
![スクリーンショット 2020-09-11 10 42 57](https://user-images.githubusercontent.com/57976204/92840003-8f147b80-f41b-11ea-8a74-98b9ffb0f0aa.png)

**変更点**
あたらにpostMap画面を作成し、ピンを動かして座標してができる様になった。ピンを長押しでピンの移動が可能。
またpinの指定された位置をReduxstoreに格納、/reducers/postPhotoReducer.tsを参照して。