### PR TITLE
Fix: 位置情報の取得で無限ループしてしまう問題の解決

### DIFF
--- a/src/components/organisms/Home.tsx
+++ b/src/components/organisms/Home.tsx
@@ -120,7 +120,7 @@ const Home: FC<Props> = ({ ...props }) => {
       });
     };
     fetch();
-  });
+  }, []);
 
   // 地図移動時付近1マイルの情報取得
   const handleRegionChange = async (region: Region) => {


### PR DESCRIPTION
## 今後のタスク
- 初回起動時(又は位置情報の設定を`次回確認`にしている場合)にwarningが出てしまう問題の修正