### PR TITLE
Add: 撮影場所を選択して投稿できる処理の追加

### DIFF
--- a/src/actions/postPhoto.ts
+++ b/src/actions/postPhoto.ts
@@ -1,7 +1,10 @@
 import { ActionTypes } from "./index";
 
 //写真一覧の情報をセット
-export const setPostPhoto = (latitude: number, longitude: number) =>
+export const setPostPhoto = (
+  latitude: number | undefined,
+  longitude: number | undefined
+) =>
   ({
     type: ActionTypes.SET_POST_PHOTO,
     payload: {

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -28,7 +28,6 @@ type Props = {
   handleContentSizeChange: (width: number, height: number) => void;
   photogenicSubject: string;
   setPhotogenicSubject: React.Dispatch<React.SetStateAction<string>>;
-  onPressLocationRow: () => void;
   navigation: any;
 };
 
@@ -42,7 +41,6 @@ const Post: FC<Props> = ({ ...props }) => {
     handleContentSizeChange,
     photogenicSubject,
     setPhotogenicSubject,
-    onPressLocationRow,
     navigation,
   } = props;
 

--- a/src/components/organisms/PostedMap.tsx
+++ b/src/components/organisms/PostedMap.tsx
@@ -2,10 +2,8 @@ import React, { FC } from "react";
 import { StyleSheet, Text, TouchableOpacity, Animated } from "react-native";
 import Spinner from "react-native-loading-spinner-overlay";
 import { Container } from "native-base";
-import { PROVIDER_GOOGLE, Marker } from "react-native-maps";
+import Map, { PROVIDER_GOOGLE, Marker } from "react-native-maps";
 import MapView from "react-native-map-clustering";
-import { useDispatch } from "react-redux";
-import { setPostPhoto } from "../../actions/postPhoto";
 
 type Region = {
   latitude: number;
@@ -18,16 +16,16 @@ type Props = {
   navigation: any;
   region: Region;
   initialRegion: Region | "loading" | undefined;
-  map: React.RefObject<MapView>;
+  map: React.RefObject<Map>;
   onLongPress: (latitude: number, longitude: number) => void;
   onRegionChangeComplete: (
     latitudeDelta: number,
     longitudeDelta: number
   ) => void;
+  dispatchPostPhoto: () => void;
 };
 
 const PostMap: FC<Props> = ({ ...props }) => {
-  const dispatch = useDispatch();
   const {
     navigation,
     region,
@@ -35,6 +33,7 @@ const PostMap: FC<Props> = ({ ...props }) => {
     map,
     onLongPress,
     onRegionChangeComplete,
+    dispatchPostPhoto,
   } = props;
 
   const AnimatedMarker = Animated.createAnimatedComponent(Marker);
@@ -75,7 +74,7 @@ const PostMap: FC<Props> = ({ ...props }) => {
           <TouchableOpacity
             style={styles.button}
             onPress={() => {
-              dispatch(setPostPhoto(region.latitude, region.longitude));
+              dispatchPostPhoto();
               navigation.goBack();
             }}
           >

--- a/src/components/organisms/PostedMap.tsx
+++ b/src/components/organisms/PostedMap.tsx
@@ -37,44 +37,43 @@ type Region = {
 type Props = {
   navigation: any;
   region: Region;
+  onLongPress: (latitude: number, longitude: number) => void;
+  onRegionChangeComplete: (
+    latitudeDelta: number,
+    longitudeDelta: number
+  ) => void;
 };
 
 const PostMap: FC<Props> = ({ ...props }) => {
   const dispatch = useDispatch();
-  const { navigation, region } = props;
-  let _map;
-  _map = React.useRef(null);
-  useEffect(() => {
-    dispatch(setPostPhoto(region.latitude, region.longitude));
-    _map.current.animateToRegion(region);
-  });
+  const { navigation, region, onLongPress, onRegionChangeComplete } = props;
 
   return (
     <Container style={styles.box}>
       <MapView
-        ref={_map}
         style={{ ...StyleSheet.absoluteFillObject }}
         provider={PROVIDER_GOOGLE}
         showsUserLocation
         initialRegion={region}
+        onLongPress={(e) =>
+          onLongPress(
+            e.nativeEvent.coordinate.latitude,
+            e.nativeEvent.coordinate.longitude
+          )
+        }
+        onRegionChangeComplete={(e) =>
+          onRegionChangeComplete(e.latitudeDelta, e.longitudeDelta)
+        }
       >
         <Marker
-          draggable
           coordinate={region}
           image={require("../../../assets/pin02.png")}
-          onDragEnd={(e) =>
-            dispatch(
-              setPostPhoto(
-                e.nativeEvent.coordinate.latitude,
-                e.nativeEvent.coordinate.longitude
-              )
-            )
-          }
         />
       </MapView>
       <TouchableOpacity
         style={styles.button}
         onPress={() => {
+          dispatch(setPostPhoto(region.latitude, region.longitude));
           navigation.goBack();
         }}
       >

--- a/src/components/organisms/PostedMap.tsx
+++ b/src/components/organisms/PostedMap.tsx
@@ -4,6 +4,7 @@ import Spinner from "react-native-loading-spinner-overlay";
 import { Container } from "native-base";
 import Map, { PROVIDER_GOOGLE, Marker } from "react-native-maps";
 import MapView from "react-native-map-clustering";
+import { baseColor } from "../../styles/thema/colors";
 
 type Region = {
   latitude: number;
@@ -78,7 +79,7 @@ const PostMap: FC<Props> = ({ ...props }) => {
               navigation.goBack();
             }}
           >
-            <Text style={styles.buttonText}>ここで決まり</Text>
+            <Text style={styles.buttonText}>ここで決定する</Text>
           </TouchableOpacity>
         </>
       )}
@@ -103,11 +104,11 @@ const styles = StyleSheet.create({
     borderTopRightRadius: 15,
     borderBottomLeftRadius: 15,
     borderBottomRightRadius: 15,
-    backgroundColor: "#f00",
+    backgroundColor: baseColor.base,
   },
   buttonText: {
     fontSize: 20,
-    color: "#fff",
+    color: baseColor.text,
   },
 });
 export default PostMap;

--- a/src/components/organisms/PostedMap.tsx
+++ b/src/components/organisms/PostedMap.tsx
@@ -18,6 +18,7 @@ type Props = {
   navigation: any;
   region: Region;
   initialRegion: Region | "loading" | undefined;
+  map: React.RefObject<MapView>;
   onLongPress: (latitude: number, longitude: number) => void;
   onRegionChangeComplete: (
     latitudeDelta: number,
@@ -31,6 +32,7 @@ const PostMap: FC<Props> = ({ ...props }) => {
     navigation,
     region,
     initialRegion,
+    map,
     onLongPress,
     onRegionChangeComplete,
   } = props;
@@ -49,6 +51,7 @@ const PostMap: FC<Props> = ({ ...props }) => {
       ) : (
         <>
           <MapView
+            ref={map}
             style={{ ...StyleSheet.absoluteFillObject }}
             provider={PROVIDER_GOOGLE}
             initialRegion={initialRegion}

--- a/src/components/organisms/PostedMap.tsx
+++ b/src/components/organisms/PostedMap.tsx
@@ -74,7 +74,8 @@ const PostMap: FC<Props> = ({ ...props }) => {
           </MapView>
           <TouchableOpacity
             style={styles.button}
-            onPress={() => {
+            // onPressにするとピンを立てた直後に効かなくなる
+            onPressOut={() => {
               dispatchPostPhoto();
               navigation.goBack();
             }}

--- a/src/components/organisms/PostedMap.tsx
+++ b/src/components/organisms/PostedMap.tsx
@@ -1,32 +1,11 @@
-import React, { FC, useState, useRef } from "react";
-import {
-  AppRegistry,
-  StyleSheet,
-  Text,
-  View,
-  ScrollView,
-  Animated,
-  Image,
-  Dimensions,
-  TouchableOpacity,
-  Platform,
-  ImageBackground,
-} from "react-native";
+import React, { FC } from "react";
+import { StyleSheet, Text, TouchableOpacity, Animated } from "react-native";
 import Spinner from "react-native-loading-spinner-overlay";
 import { Container } from "native-base";
 import { PROVIDER_GOOGLE, Marker } from "react-native-maps";
 import MapView from "react-native-map-clustering";
-import UserSwitchButtonView from "./UserSwitchButton";
-import LocationButtonView from "./PresentLocationButton";
-import OriginMarker from "../atoms/OriginMarker";
-import { useEffect } from "react";
-import { useTheme } from "@react-navigation/native";
-import { photoFireStore } from "../../firebase/photoFireStore";
-import { accountFireStore } from "../../firebase/accountFireStore";
-import { baseColor } from "../../styles/thema/colors";
-import { useSelector, useDispatch } from "react-redux";
+import { useDispatch } from "react-redux";
 import { setPostPhoto } from "../../actions/postPhoto";
-import { RootState } from "../../reducers/index";
 
 type Region = {
   latitude: number;
@@ -56,6 +35,8 @@ const PostMap: FC<Props> = ({ ...props }) => {
     onRegionChangeComplete,
   } = props;
 
+  const AnimatedMarker = Animated.createAnimatedComponent(Marker);
+
   return (
     <Container style={styles.box}>
       {initialRegion === "loading" ? (
@@ -82,7 +63,8 @@ const PostMap: FC<Props> = ({ ...props }) => {
               onRegionChangeComplete(e.latitudeDelta, e.longitudeDelta)
             }
           >
-            <Marker
+            <AnimatedMarker
+              tracksViewChanges
               coordinate={initialRegion !== undefined ? initialRegion : region}
               image={require("../../../assets/pin02.png")}
             />

--- a/src/components/organisms/PostedMap.tsx
+++ b/src/components/organisms/PostedMap.tsx
@@ -12,6 +12,7 @@ import {
   Platform,
   ImageBackground,
 } from "react-native";
+import Spinner from "react-native-loading-spinner-overlay";
 import { Container } from "native-base";
 import { PROVIDER_GOOGLE, Marker } from "react-native-maps";
 import MapView from "react-native-map-clustering";
@@ -37,6 +38,7 @@ type Region = {
 type Props = {
   navigation: any;
   region: Region;
+  initialRegion: Region | "loading" | undefined;
   onLongPress: (latitude: number, longitude: number) => void;
   onRegionChangeComplete: (
     latitudeDelta: number,
@@ -46,39 +48,56 @@ type Props = {
 
 const PostMap: FC<Props> = ({ ...props }) => {
   const dispatch = useDispatch();
-  const { navigation, region, onLongPress, onRegionChangeComplete } = props;
+  const {
+    navigation,
+    region,
+    initialRegion,
+    onLongPress,
+    onRegionChangeComplete,
+  } = props;
 
   return (
     <Container style={styles.box}>
-      <MapView
-        style={{ ...StyleSheet.absoluteFillObject }}
-        provider={PROVIDER_GOOGLE}
-        showsUserLocation
-        initialRegion={region}
-        onLongPress={(e) =>
-          onLongPress(
-            e.nativeEvent.coordinate.latitude,
-            e.nativeEvent.coordinate.longitude
-          )
-        }
-        onRegionChangeComplete={(e) =>
-          onRegionChangeComplete(e.latitudeDelta, e.longitudeDelta)
-        }
-      >
-        <Marker
-          coordinate={region}
-          image={require("../../../assets/pin02.png")}
+      {initialRegion === "loading" ? (
+        <Spinner
+          visible
+          textContent="読み込み中…"
+          textStyle={{ color: "#fff", fontSize: 13 }}
+          overlayColor="rgba(0,0,0,0.5)"
         />
-      </MapView>
-      <TouchableOpacity
-        style={styles.button}
-        onPress={() => {
-          dispatch(setPostPhoto(region.latitude, region.longitude));
-          navigation.goBack();
-        }}
-      >
-        <Text style={styles.buttonText}>ここで決まり</Text>
-      </TouchableOpacity>
+      ) : (
+        <>
+          <MapView
+            style={{ ...StyleSheet.absoluteFillObject }}
+            provider={PROVIDER_GOOGLE}
+            initialRegion={initialRegion}
+            showsUserLocation
+            onLongPress={(e) =>
+              onLongPress(
+                e.nativeEvent.coordinate.latitude,
+                e.nativeEvent.coordinate.longitude
+              )
+            }
+            onRegionChangeComplete={(e) =>
+              onRegionChangeComplete(e.latitudeDelta, e.longitudeDelta)
+            }
+          >
+            <Marker
+              coordinate={initialRegion !== undefined ? initialRegion : region}
+              image={require("../../../assets/pin02.png")}
+            />
+          </MapView>
+          <TouchableOpacity
+            style={styles.button}
+            onPress={() => {
+              dispatch(setPostPhoto(region.latitude, region.longitude));
+              navigation.goBack();
+            }}
+          >
+            <Text style={styles.buttonText}>ここで決まり</Text>
+          </TouchableOpacity>
+        </>
+      )}
     </Container>
   );
 };

--- a/src/containers/organisms/PostedMap.tsx
+++ b/src/containers/organisms/PostedMap.tsx
@@ -1,5 +1,7 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { FC, useEffect, useState, useRef } from "react";
+import { Platform } from "react-native";
 import PostMap from "../../components/organisms/PostedMap";
+import { Marker } from "react-native-maps";
 import * as Permissions from "expo-permissions";
 import * as Location from "expo-location";
 import { photoFireStore } from "../../firebase/photoFireStore";

--- a/src/containers/organisms/PostedMap.tsx
+++ b/src/containers/organisms/PostedMap.tsx
@@ -36,8 +36,8 @@ const PostedMap: FC<Props> = ({ ...props }) => {
         setRegion({
           latitude: location.coords.latitude,
           longitude: location.coords.longitude,
-          latitudeDelta: 0.1,
-          longitudeDelta: 0.1,
+          latitudeDelta: 0.015,
+          longitudeDelta: 0.015,
         });
       } catch (error) {
         // to do
@@ -46,7 +46,37 @@ const PostedMap: FC<Props> = ({ ...props }) => {
     fetch();
   }, []);
 
-  return <PostMap navigation={navigation} region={region} />;
+  const onLongPress = (latitude: number, longitude: number) => {
+    setRegion({
+      latitude,
+      longitude,
+      latitudeDelta: region.latitudeDelta,
+      longitudeDelta: region.longitudeDelta,
+    });
+  };
+
+  const onRegionChangeComplete = (
+    latitudeDelta: number,
+    longitudeDelta: number
+  ) => {
+    console.log(latitudeDelta);
+    console.log(longitudeDelta);
+    setRegion({
+      latitude: region.latitude,
+      longitude: region.longitude,
+      latitudeDelta: latitudeDelta,
+      longitudeDelta: longitudeDelta,
+    });
+  };
+
+  return (
+    <PostMap
+      navigation={navigation}
+      region={region}
+      onLongPress={onLongPress}
+      onRegionChangeComplete={onRegionChangeComplete}
+    />
+  );
 };
 
 export default PostedMap;

--- a/src/containers/organisms/PostedMap.tsx
+++ b/src/containers/organisms/PostedMap.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect, useState, useRef } from "react";
 import { Platform } from "react-native";
 import PostMap from "../../components/organisms/PostedMap";
-import { Marker } from "react-native-maps";
+import { Map } from "react-native-maps";
 import * as Permissions from "expo-permissions";
 import * as Location from "expo-location";
 import { photoFireStore } from "../../firebase/photoFireStore";
@@ -32,6 +32,7 @@ const PostedMap: FC<Props> = ({ ...props }) => {
   const [initialRegion, setInitialRegion] = useState<
     Region | "loading" | undefined
   >("loading");
+  const map = useRef<Map>(null);
 
   useEffect(() => {
     const getNowRegionAsync = async () => {
@@ -55,6 +56,10 @@ const PostedMap: FC<Props> = ({ ...props }) => {
     };
     getNowRegionAsync();
   }, []);
+
+  useEffect(() => {
+    map.current?.animateToRegion(region, 250);
+  }, [region.latitude, region.longitude]);
 
   const onLongPress = (latitude: number, longitude: number) => {
     if (!!initialRegion) setInitialRegion(undefined);
@@ -83,6 +88,7 @@ const PostedMap: FC<Props> = ({ ...props }) => {
       navigation={navigation}
       region={region}
       initialRegion={initialRegion}
+      map={map}
       onLongPress={onLongPress}
       onRegionChangeComplete={onRegionChangeComplete}
     />

--- a/src/containers/organisms/PostedMap.tsx
+++ b/src/containers/organisms/PostedMap.tsx
@@ -1,13 +1,10 @@
 import React, { FC, useEffect, useState, useRef } from "react";
-import { Platform } from "react-native";
 import PostMap from "../../components/organisms/PostedMap";
-import { Map } from "react-native-maps";
+import Map from "react-native-maps";
 import * as Permissions from "expo-permissions";
 import * as Location from "expo-location";
-import { photoFireStore } from "../../firebase/photoFireStore";
-import { useSelector, useDispatch } from "react-redux";
-import { setAllPhotoListData } from "../../actions/allPhoto";
-import { RootState } from "../../reducers/index";
+import { useDispatch } from "react-redux";
+import { setPostPhoto } from "../../actions/postPhoto";
 
 type Region = {
   latitude: number;
@@ -83,6 +80,9 @@ const PostedMap: FC<Props> = ({ ...props }) => {
     });
   };
 
+  const dispatchPostPhoto = () =>
+    dispatch(setPostPhoto(region.latitude, region.longitude));
+
   return (
     <PostMap
       navigation={navigation}
@@ -91,6 +91,7 @@ const PostedMap: FC<Props> = ({ ...props }) => {
       map={map}
       onLongPress={onLongPress}
       onRegionChangeComplete={onRegionChangeComplete}
+      dispatchPostPhoto={dispatchPostPhoto}
     />
   );
 };

--- a/src/containers/organisms/PostedMap.tsx
+++ b/src/containers/organisms/PostedMap.tsx
@@ -27,26 +27,35 @@ const PostedMap: FC<Props> = ({ ...props }) => {
     latitudeDelta: 30,
     longitudeDelta: 30,
   });
+  const [initialRegion, setInitialRegion] = useState<
+    Region | "loading" | undefined
+  >("loading");
 
   useEffect(() => {
-    const fetch = async () => {
+    const getNowRegionAsync = async () => {
       try {
         await Permissions.askAsync(Permissions.LOCATION);
         const location = await Location.getCurrentPositionAsync({});
-        setRegion({
+        setInitialRegion({
           latitude: location.coords.latitude,
           longitude: location.coords.longitude,
           latitudeDelta: 0.015,
           longitudeDelta: 0.015,
         });
       } catch (error) {
-        // to do
+        setInitialRegion({
+          latitude: region.latitude,
+          longitude: region.longitude,
+          latitudeDelta: region.latitudeDelta,
+          longitudeDelta: region.longitudeDelta,
+        });
       }
     };
-    fetch();
+    getNowRegionAsync();
   }, []);
 
   const onLongPress = (latitude: number, longitude: number) => {
+    if (!!initialRegion) setInitialRegion(undefined);
     setRegion({
       latitude,
       longitude,
@@ -59,8 +68,6 @@ const PostedMap: FC<Props> = ({ ...props }) => {
     latitudeDelta: number,
     longitudeDelta: number
   ) => {
-    console.log(latitudeDelta);
-    console.log(longitudeDelta);
     setRegion({
       latitude: region.latitude,
       longitude: region.longitude,
@@ -73,6 +80,7 @@ const PostedMap: FC<Props> = ({ ...props }) => {
     <PostMap
       navigation={navigation}
       region={region}
+      initialRegion={initialRegion}
       onLongPress={onLongPress}
       onRegionChangeComplete={onRegionChangeComplete}
     />

--- a/src/reducers/postPhotoReducer.ts
+++ b/src/reducers/postPhotoReducer.ts
@@ -2,15 +2,15 @@ import { Reducer } from "redux";
 import { ActionTypes, UnionedAction } from "../actions/index";
 
 export type State = {
-  latitude: number;
-  longitude: number;
+  latitude: number | undefined;
+  longitude: number | undefined;
 };
 
 type PostPhotoReducer = Reducer<State, UnionedAction>;
 
 const initialState: State = {
-  latitude: 0,
-  longitude: 0,
+  latitude: undefined,
+  longitude: undefined,
 };
 
 export const PostPhotoReducer: PostPhotoReducer = (

--- a/src/screens/PostScreen.tsx
+++ b/src/screens/PostScreen.tsx
@@ -20,6 +20,7 @@ export type PostScreenStackParamList = {
     };
     shouldHeaderLeftBeCross?: boolean;
   };
+  postedMap: undefined;
 };
 
 const PostScreen: FC = () => {
@@ -53,7 +54,7 @@ const PostScreen: FC = () => {
         name="postedMap"
         component={PostedMap}
         options={{
-          title: "撮影場所投稿",
+          title: "撮影場所を選択",
           headerTintColor: baseColor.text,
           headerStyle: {
             backgroundColor: baseColor.darkNavy,


### PR DESCRIPTION
## 実装の概要
 - kageyamaが作ってくれた画面を元に作成
- 閉じるボタン押下時にそのままホーム(マップ)画面に遷移するように変更
- ピンをドラッグして位置情報を決める形式だったのを、長押しでピンが立てられるように修正

## 問題点
- ピンを立てた直後に決定ボタンが押せない問題
  - `onPressOut`を使うと一応押せるようにはなったが、`OnPresIn`→`OnPressOut`が高速で発生しているらしく、押した瞬間に画面が遷移してしまう
  - しばらく格闘したが解決策が見つからなかったので取り敢えずこれで応急処置とした
- ピンを立てた後に地図を動かしてから押下すれば通常通りの挙動になる