### PR TITLE
Fix:撮影場所選択画面で決定ボタン押下時にすぐに画面が遷移してしまう問題の修正

### DIFF
--- a/src/components/organisms/PostedMap.tsx
+++ b/src/components/organisms/PostedMap.tsx
@@ -2,7 +2,7 @@ import React, { FC } from "react";
 import { StyleSheet, Text, TouchableOpacity, Animated } from "react-native";
 import Spinner from "react-native-loading-spinner-overlay";
 import { Container } from "native-base";
-import Map, { PROVIDER_GOOGLE, Marker } from "react-native-maps";
+import { PROVIDER_GOOGLE, Marker } from "react-native-maps";
 import MapView from "react-native-map-clustering";
 import { baseColor } from "../../styles/thema/colors";
 
@@ -17,7 +17,6 @@ type Props = {
   navigation: any;
   region: Region;
   initialRegion: Region | "loading" | undefined;
-  map: React.RefObject<Map>;
   onLongPress: (latitude: number, longitude: number) => void;
   onRegionChangeComplete: (
     latitudeDelta: number,
@@ -31,7 +30,6 @@ const PostMap: FC<Props> = ({ ...props }) => {
     navigation,
     region,
     initialRegion,
-    map,
     onLongPress,
     onRegionChangeComplete,
     dispatchPostPhoto,
@@ -51,7 +49,6 @@ const PostMap: FC<Props> = ({ ...props }) => {
       ) : (
         <>
           <MapView
-            ref={map}
             style={{ ...StyleSheet.absoluteFillObject }}
             provider={PROVIDER_GOOGLE}
             initialRegion={initialRegion}
@@ -74,8 +71,7 @@ const PostMap: FC<Props> = ({ ...props }) => {
           </MapView>
           <TouchableOpacity
             style={styles.button}
-            // onPressにするとピンを立てた直後に効かなくなる
-            onPressOut={() => {
+            onPress={() => {
               dispatchPostPhoto();
               navigation.goBack();
             }}

--- a/src/containers/organisms/PostedMap.tsx
+++ b/src/containers/organisms/PostedMap.tsx
@@ -1,6 +1,5 @@
 import React, { FC, useEffect, useState, useRef } from "react";
 import PostMap from "../../components/organisms/PostedMap";
-import Map from "react-native-maps";
 import * as Permissions from "expo-permissions";
 import * as Location from "expo-location";
 import { useDispatch } from "react-redux";
@@ -29,7 +28,6 @@ const PostedMap: FC<Props> = ({ ...props }) => {
   const [initialRegion, setInitialRegion] = useState<
     Region | "loading" | undefined
   >("loading");
-  const map = useRef<Map>(null);
 
   useEffect(() => {
     const getNowRegionAsync = async () => {
@@ -53,10 +51,6 @@ const PostedMap: FC<Props> = ({ ...props }) => {
     };
     getNowRegionAsync();
   }, []);
-
-  useEffect(() => {
-    map.current?.animateToRegion(region, 250);
-  }, [region.latitude, region.longitude]);
 
   const onLongPress = (latitude: number, longitude: number) => {
     if (!!initialRegion) setInitialRegion(undefined);
@@ -88,7 +82,6 @@ const PostedMap: FC<Props> = ({ ...props }) => {
       navigation={navigation}
       region={region}
       initialRegion={initialRegion}
-      map={map}
       onLongPress={onLongPress}
       onRegionChangeComplete={onRegionChangeComplete}
       dispatchPostPhoto={dispatchPostPhoto}

--- a/src/screens/PostScreen.tsx
+++ b/src/screens/PostScreen.tsx
@@ -55,6 +55,7 @@ const PostScreen: FC = () => {
         component={PostedMap}
         options={{
           title: "撮影場所を選択",
+          headerBackTitleVisible: false,
           headerTintColor: baseColor.text,
           headerStyle: {
             backgroundColor: baseColor.darkNavy,


### PR DESCRIPTION
## 実装の概要
- 撮影場所選択画面で決定ボタン押下時にすぐに画面が遷移してしまう問題の修正
- 上記を解決するために、ピンを立てた時に画面が追従してくるアニメーションは削除した