### PR TITLE
Fix: カードのsubjectをnameに戻し、無限ループバグを解決した

### DIFF
--- a/src/components/organisms/Home.tsx
+++ b/src/components/organisms/Home.tsx
@@ -199,16 +199,21 @@ const Home: FC<Props> = ({ ...props }) => {
   };
 
   // ユーザー名の取得
-  // const getUserName = (uid: string) => {
-  //   accountFireStore
-  //     .getUserName(uid)
-  //     .then((res: React.SetStateAction<string>) => {
-  //       setPostUserName(res);
-  //     })
-  //     .catch(() => {
-  //       setPostUserName("名無し");
-  //     });
-  // };
+  useEffect(() => {
+    const getUserName = (uid: string) => {
+      accountFireStore
+        .getUserName(uid)
+        .then((res: React.SetStateAction<string>) => {
+          setPostUserName(res);
+        })
+        .catch(() => {
+          setPostUserName("名無し");
+        });
+    };
+    photoSnapList.map((data) => {
+      getUserName(data.uid);
+    });
+  }, [photoSnapList]);
 
   return (
     <Container>
@@ -366,8 +371,9 @@ const Home: FC<Props> = ({ ...props }) => {
                         resizeMode="cover"
                       />
                       <Text style={styles.cardText}>
-                        {data.photogenic_subject}
-                        {/* <Text style={styles.cardTextSub}>さんの投稿</Text> */}
+                        {/* {data.photogenic_subject} */}
+                        {postUserName}
+                        <Text style={styles.cardTextSub}>さんの投稿</Text>
                       </Text>
                     </TouchableOpacity>
                   );

--- a/src/components/organisms/Home.tsx
+++ b/src/components/organisms/Home.tsx
@@ -122,6 +122,23 @@ const Home: FC<Props> = ({ ...props }) => {
     fetch();
   });
 
+  // ユーザー名の取得
+  useEffect(() => {
+    const getUserName = (uid: string) => {
+      accountFireStore
+        .getUserName(uid)
+        .then((res: React.SetStateAction<string>) => {
+          setPostUserName(res);
+        })
+        .catch(() => {
+          setPostUserName("名無し");
+        });
+    };
+    photoSnapList.map((data) => {
+      getUserName(data.uid);
+    });
+  }, [photoSnapList]);
+
   // 地図移動時付近1マイルの情報取得
   const handleRegionChange = async (region: Region) => {
     if (photoPinFlag) {
@@ -197,23 +214,6 @@ const Home: FC<Props> = ({ ...props }) => {
     setPhotoSnapList([data]);
     setPhotoSnapFlag(true);
   };
-
-  // ユーザー名の取得
-  useEffect(() => {
-    const getUserName = (uid: string) => {
-      accountFireStore
-        .getUserName(uid)
-        .then((res: React.SetStateAction<string>) => {
-          setPostUserName(res);
-        })
-        .catch(() => {
-          setPostUserName("名無し");
-        });
-    };
-    photoSnapList.map((data) => {
-      getUserName(data.uid);
-    });
-  }, [photoSnapList]);
 
   return (
     <Container>

--- a/src/components/organisms/Home.tsx
+++ b/src/components/organisms/Home.tsx
@@ -79,8 +79,21 @@ const Home: FC<Props> = ({ ...props }) => {
     _map.current.animateToRegion(region);
   }, [_map.current]);
 
-  // photoSnap参考資料　https://www.youtube.com/watch?v=2vILzRmEqGI
+  // photoSnapListが更新される度に実行
   useEffect(() => {
+    // ユーザー名の取得
+    const getUserName = (uid: string) => {
+      accountFireStore
+        .getUserName(uid)
+        .then((res: React.SetStateAction<string>) => {
+          setPostUserName(res);
+        })
+        .catch(() => {
+          setPostUserName("名無し");
+        });
+    };
+
+    // photoSnap参考資料　https://www.youtube.com/watch?v=2vILzRmEqGI
     const fetch = async () => {
       mapAnimation.addListener(({ value }) => {
         let index = Math.floor(value / CARD_WIDTH + 0.3); // animate 30% away from landing on the next item
@@ -119,24 +132,10 @@ const Home: FC<Props> = ({ ...props }) => {
       });
     };
 
-    fetch();
-  });
-
-  // ユーザー名の取得
-  useEffect(() => {
-    const getUserName = (uid: string) => {
-      accountFireStore
-        .getUserName(uid)
-        .then((res: React.SetStateAction<string>) => {
-          setPostUserName(res);
-        })
-        .catch(() => {
-          setPostUserName("名無し");
-        });
-    };
     photoSnapList.map((data) => {
       getUserName(data.uid);
     });
+    fetch();
   }, [photoSnapList]);
 
   // 地図移動時付近1マイルの情報取得

--- a/src/containers/organisms/Post.tsx
+++ b/src/containers/organisms/Post.tsx
@@ -6,6 +6,7 @@ import {
   Image,
   ScrollView,
   StyleSheet,
+  BackHandler,
 } from "react-native";
 import type { Dispatch } from "redux";
 import type { NavigationProp } from "@react-navigation/core/lib/typescript/src/types";
@@ -324,6 +325,13 @@ const PostContainer: FC<Props> = ({ ...props }) => {
   };
 
   assignImageAspectRatio(uri, setAspectRatio);
+
+  const onPressAndroidBack = () => {
+    moveToPreviousTab(dispatch);
+    return true;
+  };
+
+  BackHandler.addEventListener("hardwareBackPress", onPressAndroidBack);
 
   return (
     <>


### PR DESCRIPTION
## 実装の概要
### カードのsubjectをnameに戻した
- 過去のコードで無限ループバグが起きていた原因は、`return`の中で`getUserName`メソッドを実行していたことだった
  - ここに記述してしまうと**レンダリングの度に実行されてしまう**ため、`props`やuseStateの`state`が変更される度に実行されてしまっていた
- `photoSnapList`を第二引数に格納したuseEffectを使うことで、下に表示されるカードリストの情報が更新された時にのみ実行されるようにした
### fetch関数を第二引数`photoSnap`の`useEffect`に移動させた
- 今まで`fetch`は第二引数の`useEffect`に格納されていた
  - 第二引数なしの`useEffect`は上記に書いた通りパフォーマンスがかなり悪い
    - 参考: [【React】useEffectの第２引数って？ - Qiita](https://qiita.com/k-penguin-sato/items/9373d87c57da3b74a9e6)
- どうにかしたいと思い試しに第二引数を`photoSnap`にしたら問題なく動いたのでこっちに変更した
## Android端末でバックボタンを押した時のバグを修正
- 投稿画面からAndroid端末付属のバックボタンを押下した際にボトムナビが消えたままになってしまうバグを解消した

## 確認して欲しい点
- 一応実機で動作確認をして「無限ループは直った」と判断したが、不安なので一応再確認をお願いします🙏
- カードのアニメーションについても動作確認お願いします
- バックボタンについては動作確認済みなので大丈夫です🙆‍♂️