### PR TITLE
Revert "Fix: カードのsubjectをnameに戻し、無限ループバグを解決した"

### DIFF
--- a/src/components/organisms/Home.tsx
+++ b/src/components/organisms/Home.tsx
@@ -79,21 +79,8 @@ const Home: FC<Props> = ({ ...props }) => {
     _map.current.animateToRegion(region);
   }, [_map.current]);
 
-  // photoSnapListが更新される度に実行
+  // photoSnap参考資料　https://www.youtube.com/watch?v=2vILzRmEqGI
   useEffect(() => {
-    // ユーザー名の取得
-    const getUserName = (uid: string) => {
-      accountFireStore
-        .getUserName(uid)
-        .then((res: React.SetStateAction<string>) => {
-          setPostUserName(res);
-        })
-        .catch(() => {
-          setPostUserName("名無し");
-        });
-    };
-
-    // photoSnap参考資料　https://www.youtube.com/watch?v=2vILzRmEqGI
     const fetch = async () => {
       mapAnimation.addListener(({ value }) => {
         let index = Math.floor(value / CARD_WIDTH + 0.3); // animate 30% away from landing on the next item
@@ -132,11 +119,8 @@ const Home: FC<Props> = ({ ...props }) => {
       });
     };
 
-    photoSnapList.map((data) => {
-      getUserName(data.uid);
-    });
     fetch();
-  }, [photoSnapList]);
+  });
 
   // 地図移動時付近1マイルの情報取得
   const handleRegionChange = async (region: Region) => {
@@ -213,6 +197,18 @@ const Home: FC<Props> = ({ ...props }) => {
     setPhotoSnapList([data]);
     setPhotoSnapFlag(true);
   };
+
+  // ユーザー名の取得
+  // const getUserName = (uid: string) => {
+  //   accountFireStore
+  //     .getUserName(uid)
+  //     .then((res: React.SetStateAction<string>) => {
+  //       setPostUserName(res);
+  //     })
+  //     .catch(() => {
+  //       setPostUserName("名無し");
+  //     });
+  // };
 
   return (
     <Container>
@@ -370,9 +366,8 @@ const Home: FC<Props> = ({ ...props }) => {
                         resizeMode="cover"
                       />
                       <Text style={styles.cardText}>
-                        {/* {data.photogenic_subject} */}
-                        {postUserName}
-                        <Text style={styles.cardTextSub}>さんの投稿</Text>
+                        {data.photogenic_subject}
+                        {/* <Text style={styles.cardTextSub}>さんの投稿</Text> */}
                       </Text>
                     </TouchableOpacity>
                   );

--- a/src/containers/organisms/Post.tsx
+++ b/src/containers/organisms/Post.tsx
@@ -6,7 +6,6 @@ import {
   Image,
   ScrollView,
   StyleSheet,
-  BackHandler,
 } from "react-native";
 import type { Dispatch } from "redux";
 import type { NavigationProp } from "@react-navigation/core/lib/typescript/src/types";
@@ -325,13 +324,6 @@ const PostContainer: FC<Props> = ({ ...props }) => {
   };
 
   assignImageAspectRatio(uri, setAspectRatio);
-
-  const onPressAndroidBack = () => {
-    moveToPreviousTab(dispatch);
-    return true;
-  };
-
-  BackHandler.addEventListener("hardwareBackPress", onPressAndroidBack);
 
   return (
     <>


### PR DESCRIPTION
**一旦Revert**
実装の概要
カードのsubjectをnameに戻した
過去のコードで無限ループバグが起きていた原因は、returnの中でgetUserNameメソッドを実行していたことだった
ここに記述してしまうとレンダリングの度に実行されてしまうため、propsやuseStateのstateが変更される度に実行されてしまっていた
photoSnapListを第二引数に格納したuseEffectを使うことで、下に表示されるカードリストの情報が更新された時にのみ実行されるようにした
fetch関数を第二引数photoSnapのuseEffectに移動させた
今までfetchは第二引数のuseEffectに格納されていた
第二引数なしのuseEffectは上記に書いた通りパフォーマンスがかなり悪い
参考: 【React】useEffectの第２引数って？ - Qiita
どうにかしたいと思い試しに第二引数をphotoSnapにしたら問題なく動いたのでこっちに変更した
Android端末でバックボタンを押した時のバグを修正
投稿画面からAndroid端末付属のバックボタンを押下した際にボトムナビが消えたままになってしまうバグを解消した
確認して欲しい点
一応実機で動作確認をして「無限ループは直った」と判断したが、不安なので一応再確認をお願いします🙏
カードのアニメーションについても動作確認お願いします
バックボタンについては動作確認済みなので大丈夫です🙆‍♂️