### PR TITLE
Add: 投稿時にfirestoreにimg_indexという名前でstorageに格納した写真のファイル名を保存できるようにした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ npm-debug.*
 *.orig.*
 web-build/
 web-report/
+.idea/*
 
 # macOS
 .DS_Store

--- a/src/containers/molecules/Card.tsx
+++ b/src/containers/molecules/Card.tsx
@@ -25,6 +25,8 @@ const CardContainer: FC<Props> = ({ ...props }) => {
 
   // ユーザー名の取得
   const getUserName = (uid: string) => {
+    // isMounted === trueの時はuseState関連の処理を行わないようにする
+    // "Can only update a mounted or mounting component"Warningエラーを起こさないために必要
     if (!isMounted) return;
     accountFireStore
       .getUserName(uid)

--- a/src/containers/organisms/Post.tsx
+++ b/src/containers/organisms/Post.tsx
@@ -117,20 +117,21 @@ const checkError = (
 const uploadToStorage = async (
   uid: string,
   uri: string
-): Promise<undefined | string> => {
-  const ref = postFirebaseStorage.getUploadRef(uid);
+): Promise<{ url: string | null; filename: string | null }> => {
+  const { uploadRef: ref, filename } = postFirebaseStorage.getUploadRef(uid);
   const storageResult = await postFirebaseStorage.uploadPostImage(ref, uri);
-  if (storageResult === "error") return;
+  if (storageResult === "error") return { url: null, filename: null };
   const url = await postFirebaseStorage.getImageUrl(ref);
-  if (url === "error") return;
-  return url;
+  if (url === "error") return { url: null, filename: null };
+  return { url, filename };
 };
 
 const uploadToFirestore = async (
   uid: string,
   url: string,
   photogenicSubject: string,
-  location: Location
+  location: Location,
+  filename: string
 ): Promise<undefined | DocumentData> => {
   if (location.latitude === undefined) return;
   if (location.longitude === undefined) return;
@@ -140,6 +141,7 @@ const uploadToFirestore = async (
     uid,
     url,
     photogenicSubject,
+    filename,
   });
   const docId = firestoreResult.docId;
   if (firestoreResult.state === "error" || docId === undefined) return;
@@ -159,9 +161,15 @@ const uploadPostImage = async (
   photogenicSubject: string,
   location: Location
 ): Promise<undefined | DocumentData> => {
-  const url = await uploadToStorage(uid, uri);
-  if (!url) return;
-  const data = await uploadToFirestore(uid, url, photogenicSubject, location);
+  const { url, filename } = await uploadToStorage(uid, uri);
+  if (!url || !filename) return;
+  const data = await uploadToFirestore(
+    uid,
+    url,
+    photogenicSubject,
+    location,
+    filename
+  );
   return data;
 };
 
@@ -330,7 +338,6 @@ const PostContainer: FC<Props> = ({ ...props }) => {
     moveToPreviousTab(dispatch);
     return true;
   };
-
   BackHandler.addEventListener("hardwareBackPress", onPressAndroidBack);
 
   return (

--- a/src/firebase/postFireStore.ts
+++ b/src/firebase/postFireStore.ts
@@ -8,6 +8,7 @@ type PhotoData = {
   photogenicSubject: string;
   uid: string;
   url: string;
+  filename: string;
 };
 type PostFireStore = {
   addImageData: (data: PhotoData) => Promise<{ state: string; docId?: string }>;
@@ -22,7 +23,7 @@ const photosRef = db.collection("photos");
 export const postFireStore: PostFireStore = {
   // photosコレクションにデータを追加
   addImageData: (data: PhotoData) => {
-    const { latitude, longitude, photogenicSubject, uid, url } = data;
+    const { latitude, longitude, photogenicSubject, uid, url, filename } = data;
     const geohashStr = geohash.encode(latitude, longitude);
     return new Promise((resolve) => {
       photosRef
@@ -35,6 +36,7 @@ export const postFireStore: PostFireStore = {
           photogenic_subject: photogenicSubject,
           uid,
           url,
+          img_index: filename,
         })
         .then(async (docRef) => {
           const addIdResult = await postFireStore.addPhotoId(docRef.id);

--- a/src/firebase/postFirebaseStorage.ts
+++ b/src/firebase/postFirebaseStorage.ts
@@ -1,7 +1,7 @@
 import { Reference, storageRef } from "./firebase";
 
 type PostFirebaseStorage = {
-  getUploadRef: (uid: string) => Reference;
+  getUploadRef: (uid: string) => { uploadRef: Reference; filename: string };
   uploadPostImage: (ref: Reference, uri: string) => Promise<string>;
   getImageUrl: (ref: Reference) => Promise<string>;
 };
@@ -11,7 +11,7 @@ export const postFirebaseStorage: PostFirebaseStorage = {
   getUploadRef: (uid: string) => {
     const filename = Date.now().toString();
     const uploadRef = storageRef.child(`photo/${uid}/${filename}`);
-    return uploadRef;
+    return { uploadRef, filename };
   },
   // 画像をstorageに保存
   uploadPostImage: async (ref: Reference, uri: string) => {
@@ -21,7 +21,7 @@ export const postFirebaseStorage: PostFirebaseStorage = {
     return new Promise((resolve) => {
       ref
         .put(blob, metadata)
-        .then((snapshot) => {
+        .then(() => {
           resolve("success");
         })
         .catch((error) => {


### PR DESCRIPTION
## 実装の概要
- 投稿時にfirestoreに`img_index`というフィールド名でstorageに格納した写真のファイル名を保存できるようにした