### PR TITLE
ユーザー投稿画像取得をfilterに変更

### DIFF
--- a/src/components/organisms/Home.tsx
+++ b/src/components/organisms/Home.tsx
@@ -40,10 +40,10 @@ type PhotoDataList = {
 type Props = {
   navigation: any;
   allPhotoList: firebase.firestore.DocumentData[];
-  myPhotoList: firebase.firestore.DocumentData[];
   bottomHeight: number;
   region: Region;
   initialRegion: Region | "loading";
+  myUid: string;
 };
 
 const { width, height } = Dimensions.get("window");
@@ -60,11 +60,12 @@ const Home: FC<Props> = ({ ...props }) => {
   const {
     navigation,
     allPhotoList,
-    myPhotoList,
     bottomHeight,
     region,
     initialRegion,
+    myUid,
   } = props;
+  const [myPhotoList, setMyPhotoList] = useState<any>();
   const [photoDisplayFlag, setPhotoDisplayFlag] = useState(true);
   const [photoSnapFlag, setPhotoSnapFlag] = useState(false);
   const [photoPinFlag, setPhotoPinFlag] = useState(false);
@@ -77,6 +78,10 @@ const Home: FC<Props> = ({ ...props }) => {
     if (_map.current === null) return;
     _map.current.animateToRegion(region);
   }, [_map.current]);
+
+  useEffect(() => {
+    setMyPhotoList(allPhotoList.filter((photo) => photo.uid === myUid));
+  }, [allPhotoList]);
 
   // photoSnapListが更新される度に実行
   useEffect(() => {

--- a/src/containers/organisms/Home.tsx
+++ b/src/containers/organisms/Home.tsx
@@ -18,14 +18,13 @@ const ContainerHome: FC<Props> = ({ ...props }) => {
   const dispatch = useDispatch();
   const selectAllPhotoDataList = (state: RootState) =>
     state.allPhotoReducer.allPhotoDataList;
-  const selectPhotoDataList = (state: RootState) =>
-    state.myPhotoReducer.photoDataList;
   const selectBottomHeight = (state: RootState) =>
     state.bottomNavReducer.height;
+  const selectMyuid = (state: RootState) => state.userReducer.uid;
 
   const allPhotoList = useSelector(selectAllPhotoDataList);
-  const myPhotoDataList = useSelector(selectPhotoDataList);
   const bottomHeight = useSelector(selectBottomHeight);
+  const myUid = useSelector(selectMyuid);
   const [region, setRegion] = useState<Region>({
     latitude: 35.6809591,
     longitude: 139.7673068,
@@ -79,10 +78,10 @@ const ContainerHome: FC<Props> = ({ ...props }) => {
     <Home
       navigation={navigation}
       allPhotoList={allPhotoList}
-      myPhotoList={myPhotoDataList}
       bottomHeight={bottomHeight}
       region={region}
       initialRegion={initialRegion}
+      myUid={myUid}
     />
   );
 };


### PR DESCRIPTION
今までfirestoreへ参照していたユーザー投稿写真取得を。
全体画像からfilterを利用して抽出する方法に変更