### PR TITLE
Fix: 気になる箇所の修正、Add: 圧縮処理の追加

### DIFF
--- a/src/ScreenSwitcher.tsx
+++ b/src/ScreenSwitcher.tsx
@@ -11,7 +11,7 @@ import { newsFireStore } from "./firebase/newsFireStore";
 import { RootState } from "./reducers/index";
 import { loadingStatusChange, loginStatusChange } from "./actions/auth";
 import { setUserData } from "./actions/user";
-import { setPhotoListData } from "./actions/photo";
+import { setPhotoDataList } from "./actions/photo";
 import { setAllPhotoListData } from "./actions/allPhoto";
 import { setNewsDataList } from "./actions/news ";
 import { setNotificationDataList } from "./actions/notification";
@@ -115,7 +115,7 @@ const ScreenSwitcher: FC = () => {
 
   useEffect(() => {
     const filter = allPhotoDataList.filter((value) => value.uid === uid);
-    dispatch(setPhotoListData(filter));
+    dispatch(setPhotoDataList(filter));
   }, [allPhotoDataList]);
 
   useEffect(() => {

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,5 +1,5 @@
 import { loadingStatusChange, loginStatusChange } from "./auth";
-import { setPhotoListData } from "./photo";
+import { setPhotoDataList } from "./photo";
 import { setNewsDataList } from "./news ";
 import { setAllPhotoListData } from "./allPhoto";
 import {
@@ -56,7 +56,7 @@ export type UnionedAction =
   | ReturnType<typeof loadingStatusChange>
   | ReturnType<typeof loginStatusChange>
   | ReturnType<typeof setUserData>
-  | ReturnType<typeof setPhotoListData>
+  | ReturnType<typeof setPhotoDataList>
   | ReturnType<typeof setAllPhotoListData>
   | ReturnType<typeof setCommentDataList>
   | ReturnType<typeof setIsInputForm>

--- a/src/actions/photo.ts
+++ b/src/actions/photo.ts
@@ -1,7 +1,7 @@
 import { ActionTypes } from "./index";
 
 //写真一覧の情報をセット
-export const setPhotoListData = (
+export const setPhotoDataList = (
   photoDataList: firebase.firestore.DocumentData[]
 ) =>
   ({

--- a/src/components/molecules/Card.tsx
+++ b/src/components/molecules/Card.tsx
@@ -18,13 +18,14 @@ type Props = {
   navigation: any;
   data: PhotoDataList;
   postUserName: string;
+  aspectRatio: number;
 };
 
 const CARD_HEIGHT = 220;
 const CARD_WIDTH = deviceWidth * 0.8;
 
 const Card: FC<Props> = ({ ...props }) => {
-  const { navigation, data, postUserName } = props;
+  const { navigation, data, postUserName, aspectRatio } = props;
   return (
     <TouchableOpacity
       activeOpacity={0.85}
@@ -40,6 +41,7 @@ const Card: FC<Props> = ({ ...props }) => {
             latitude: data.latitude,
             longitude: data.longitude,
             photogenic_subject: data.photogenic_subject,
+            aspectRatio,
           },
         });
       }}

--- a/src/components/molecules/ImageListItem.tsx
+++ b/src/components/molecules/ImageListItem.tsx
@@ -1,0 +1,100 @@
+import React, { FC } from "react";
+import { View, TouchableOpacity } from "react-native";
+import { StyleSheet, ActivityIndicator } from "react-native";
+import { heightPercentageToDP as hp } from "react-native-responsive-screen";
+import { Image } from "react-native-elements";
+import { Timestamp } from "@google-cloud/firestore";
+import { StackNavigationProp } from "@react-navigation/stack";
+import { HomeScreenStackParamList } from "../../screens/HomeScreen";
+import { PickUpScreenStackParamList } from "../../screens/PickUpScreen";
+import { UserScreenStackParamList } from "../../screens/UserScreen";
+import { deviceWidth } from "../../utilities/dimensions";
+import InformationUserPosted from "../../containers/molecules/InformationUserPosted";
+import PostedPageItems from "../../containers/molecules/PostedPageItems";
+
+type ImageListScreenNavigationProp = StackNavigationProp<
+  | HomeScreenStackParamList
+  | PickUpScreenStackParamList
+  | UserScreenStackParamList,
+  "detail"
+>;
+
+type PhotoDataList = {
+  photo_id: string;
+  uid: string;
+  create_time: Timestamp;
+  url: string;
+  latitude: number;
+  longitude: number;
+  photogenic_subject: string;
+  img_index: string;
+};
+
+type Props = {
+  item: PhotoDataList;
+  navigation: ImageListScreenNavigationProp;
+  isLast: boolean;
+  aspectRatio: number;
+};
+
+const ImageListItem: FC<Props> = ({ ...props }) => {
+  const { item, navigation, isLast, aspectRatio } = props;
+
+  return (
+    <View style={isLast ? {} : styles.itemWrap}>
+      <InformationUserPosted
+        navigation={navigation}
+        uid={item.uid}
+        photo_id={item.photo_id}
+        photogenic_subject={item.photogenic_subject}
+        img_index={item.img_index}
+        url={item.url}
+      />
+      <TouchableOpacity
+        activeOpacity={0.8}
+        onPress={() =>
+          navigation.navigate("post", {
+            imageData: {
+              photo_id: item.photo_id,
+              uid: item.uid,
+              create_time: item.create_time,
+              url: item.url,
+              latitude: item.latitude,
+              longitude: item.longitude,
+              photogenic_subject: item.photogenic_subject,
+              img_index: item.img_index,
+              aspectRatio,
+            },
+          })
+        }
+      >
+        <Image
+          style={styles.imageSize}
+          source={{ uri: item.url }}
+          PlaceholderContent={<ActivityIndicator />}
+        />
+      </TouchableOpacity>
+      <PostedPageItems
+        navigation={navigation}
+        photo_id={item.photo_id}
+        uid={item.uid}
+        create_time={item.create_time}
+        url={item.url}
+        latitude={item.latitude}
+        longitude={item.longitude}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  itemWrap: {
+    marginBottom: hp("1.5%"),
+  },
+  imageSize: {
+    width: deviceWidth,
+    height: deviceWidth,
+  },
+});
+
+export default ImageListItem;

--- a/src/components/molecules/PhotoDataItem.tsx
+++ b/src/components/molecules/PhotoDataItem.tsx
@@ -1,0 +1,57 @@
+import React, { FC } from "react";
+import { ActivityIndicator, TouchableOpacity } from "react-native";
+import { StyleSheet } from "react-native";
+import { Image } from "react-native-elements";
+import { StackNavigationProp } from "@react-navigation/stack";
+import { UserScreenStackParamList } from "../../screens/UserScreen";
+import { deviceWidth } from "../../utilities/dimensions";
+
+type UserScreenNavigationProp = StackNavigationProp<UserScreenStackParamList>;
+
+type Props = {
+  navigation: UserScreenNavigationProp;
+  item: firebase.firestore.DocumentData;
+  aspectRatio: number;
+};
+
+const PhotoDataItem: FC<Props> = ({ navigation, item, aspectRatio }) => {
+  return (
+    <TouchableOpacity
+      activeOpacity={0.8}
+      onPress={() =>
+        navigation.push("post", {
+          imageData: {
+            photo_id: item.photo_id,
+            uid: item.uid,
+            create_time: item.create_time,
+            url: item.url,
+            favoriteNumber: item.favoriteNumber,
+            latitude: item.latitude,
+            longitude: item.longitude,
+            photogenic_subject: item.photogenic_subject,
+            img_index: item.img_index,
+            aspectRatio,
+          },
+        })
+      }
+    >
+      <Image
+        style={styles.image}
+        PlaceholderContent={<ActivityIndicator />}
+        source={{
+          uri: item.url,
+        }}
+      />
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  image: {
+    width: deviceWidth / 3.05,
+    height: deviceWidth / 3.05,
+    margin: deviceWidth / 370,
+  },
+});
+
+export default PhotoDataItem;

--- a/src/components/molecules/PostedPageItems.tsx
+++ b/src/components/molecules/PostedPageItems.tsx
@@ -24,6 +24,7 @@ type Props = {
   commentCount: number;
   isFavoriteStatus: boolean;
   pressedFavorite: () => Promise<void>;
+  aspectRatio: number;
 };
 
 const PostedPageItems: FC<Props> = ({ ...props }) => {
@@ -40,6 +41,7 @@ const PostedPageItems: FC<Props> = ({ ...props }) => {
     commentCount,
     isFavoriteStatus,
     pressedFavorite,
+    aspectRatio,
   } = props;
 
   return (
@@ -72,6 +74,7 @@ const PostedPageItems: FC<Props> = ({ ...props }) => {
                 favoriteNumber,
                 latitude,
                 longitude,
+                aspectRatio,
               },
             })
           }

--- a/src/components/molecules/TabMenu.tsx
+++ b/src/components/molecules/TabMenu.tsx
@@ -1,14 +1,13 @@
 import React, { FC } from "react";
-import { View, ActivityIndicator, TouchableOpacity } from "react-native";
+import { View } from "react-native";
 import { StyleSheet } from "react-native";
 import { Tab, Tabs, TabHeading } from "native-base";
-import { Image } from "react-native-elements";
 import { widthPercentageToDP as wp } from "react-native-responsive-screen";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { UserScreenStackParamList } from "../../screens/UserScreen";
 import { baseColor } from "../../styles/thema/colors";
-import { deviceWidth } from "../../utilities/dimensions";
 import Icon from "react-native-vector-icons/FontAwesome";
+import PhotoDataItem from "../../containers/molecules/PhotoDataItem";
 
 type UserScreenNavigationProp = StackNavigationProp<UserScreenStackParamList>;
 
@@ -36,33 +35,7 @@ const TabMenu: FC<Props> = ({ navigation, photoDataList, favoriteItems }) => {
         <View style={styles.imgItemWrap}>
           {photoDataList !== undefined &&
             photoDataList.map((item, index) => (
-              <TouchableOpacity
-                key={index}
-                activeOpacity={0.8}
-                onPress={() =>
-                  navigation.push("post", {
-                    imageData: {
-                      photo_id: item.photo_id,
-                      uid: item.uid,
-                      create_time: item.create_time,
-                      url: item.url,
-                      favoriteNumber: item.favoriteNumber,
-                      latitude: item.latitude,
-                      longitude: item.longitude,
-                      photogenic_subject: item.photogenic_subject,
-                      img_index: item.img_index,
-                    },
-                  })
-                }
-              >
-                <Image
-                  style={styles.image}
-                  PlaceholderContent={<ActivityIndicator />}
-                  source={{
-                    uri: item.url,
-                  }}
-                />
-              </TouchableOpacity>
+              <PhotoDataItem navigation={navigation} item={item} key={index} />
             ))}
         </View>
       </Tab>
@@ -76,33 +49,7 @@ const TabMenu: FC<Props> = ({ navigation, photoDataList, favoriteItems }) => {
         <View style={styles.imgItemWrap}>
           {favoriteItems !== undefined &&
             favoriteItems.map((item, index) => (
-              <TouchableOpacity
-                key={index}
-                activeOpacity={0.8}
-                onPress={() =>
-                  navigation.push("post", {
-                    imageData: {
-                      photo_id: item.photo_id,
-                      uid: item.uid,
-                      create_time: item.create_time,
-                      url: item.url,
-                      favoriteNumber: item.favoriteNumber,
-                      latitude: item.latitude,
-                      longitude: item.longitude,
-                      photogenic_subject: item.photogenic_subject,
-                      img_index: item.img_index,
-                    },
-                  })
-                }
-              >
-                <Image
-                  style={styles.image}
-                  PlaceholderContent={<ActivityIndicator />}
-                  source={{
-                    uri: item.url,
-                  }}
-                />
-              </TouchableOpacity>
+              <PhotoDataItem navigation={navigation} item={item} key={index} />
             ))}
         </View>
       </Tab>
@@ -117,11 +64,6 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     flexWrap: "wrap",
     backgroundColor: baseColor.base,
-  },
-  image: {
-    width: deviceWidth / 3.05,
-    height: deviceWidth / 3.05,
-    margin: deviceWidth / 370,
   },
 });
 

--- a/src/components/organisms/ImageList.tsx
+++ b/src/components/organisms/ImageList.tsx
@@ -1,18 +1,15 @@
 import React, { FC } from "react";
-import { ScrollView, View, TouchableOpacity } from "react-native";
-import { StyleSheet, ActivityIndicator } from "react-native";
+import { ScrollView, View } from "react-native";
+import { StyleSheet } from "react-native";
 import { widthPercentageToDP as wp } from "react-native-responsive-screen";
 import { heightPercentageToDP as hp } from "react-native-responsive-screen";
-import { Image } from "react-native-elements";
 import { Timestamp } from "@google-cloud/firestore";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { HomeScreenStackParamList } from "../../screens/HomeScreen";
 import { PickUpScreenStackParamList } from "../../screens/PickUpScreen";
 import { UserScreenStackParamList } from "../../screens/UserScreen";
 import { baseColor } from "../../styles/thema/colors";
-import { deviceWidth } from "../../utilities/dimensions";
-import InformationUserPosted from "../../containers/molecules/InformationUserPosted";
-import PostedPageItems from "../../containers/molecules/PostedPageItems";
+import ImageListItem from "../../containers/molecules/ImageListItem";
 
 type ImageListScreenNavigationProp = StackNavigationProp<
   | HomeScreenStackParamList
@@ -47,48 +44,12 @@ const ImageList: FC<Props> = ({ ...props }) => {
         {photoDataList.map((item, index) => {
           const isLast = photoDataList.length - 1 === index;
           return (
-            <View style={isLast ? {} : styles.itemWrap} key={index}>
-              <InformationUserPosted
-                navigation={navigation}
-                uid={item.uid}
-                photo_id={item.photo_id}
-                photogenic_subject={item.photogenic_subject}
-                img_index={item.img_index}
-                url={item.url}
-              />
-              <TouchableOpacity
-                activeOpacity={0.8}
-                onPress={() =>
-                  navigation.navigate("post", {
-                    imageData: {
-                      photo_id: item.photo_id,
-                      uid: item.uid,
-                      create_time: item.create_time,
-                      url: item.url,
-                      latitude: item.latitude,
-                      longitude: item.longitude,
-                      photogenic_subject: item.photogenic_subject,
-                      img_index: item.img_index,
-                    },
-                  })
-                }
-              >
-                <Image
-                  style={styles.imageSize}
-                  source={{ uri: item.url }}
-                  PlaceholderContent={<ActivityIndicator />}
-                />
-              </TouchableOpacity>
-              <PostedPageItems
-                navigation={navigation}
-                photo_id={item.photo_id}
-                uid={item.uid}
-                create_time={item.create_time}
-                url={item.url}
-                latitude={item.latitude}
-                longitude={item.longitude}
-              />
-            </View>
+            <ImageListItem
+              item={item}
+              navigation={navigation}
+              isLast={isLast}
+              key={index}
+            />
           );
         })}
       </View>
@@ -104,13 +65,6 @@ const styles = StyleSheet.create({
   },
   allWrap: {
     width: wp("100%"),
-  },
-  itemWrap: {
-    marginBottom: hp("1.5%"),
-  },
-  imageSize: {
-    width: deviceWidth,
-    height: deviceWidth,
   },
 });
 

--- a/src/components/organisms/PostedImageDetail.tsx
+++ b/src/components/organisms/PostedImageDetail.tsx
@@ -37,6 +37,7 @@ type Props = {
   textInputRef: MutableRefObject<TextInput | null>;
   bottomHeight: number;
   img_index: string;
+  aspectRatio: number;
   focusOnInput: () => void;
 };
 
@@ -55,6 +56,7 @@ const PostedImageDetail: FC<Props> = ({ ...props }) => {
     focusOnInput,
     bottomHeight,
     img_index,
+    aspectRatio,
   } = props;
 
   return (
@@ -73,7 +75,7 @@ const PostedImageDetail: FC<Props> = ({ ...props }) => {
             <Image
               style={{
                 width: deviceWidth,
-                height: deviceWidth,
+                height: deviceWidth * aspectRatio,
               }}
               source={{
                 uri: url,

--- a/src/containers/molecules/CameraAlbumWrap.tsx
+++ b/src/containers/molecules/CameraAlbumWrap.tsx
@@ -7,6 +7,8 @@ import type { BottomTabBarProps } from "@react-navigation/bottom-tabs/lib/typesc
 import type { NavigationState } from "@react-navigation/routers/lib/typescript/src/types";
 import * as ImagePicker from "expo-image-picker";
 import * as Permissions from "expo-permissions";
+import * as ImageManipulator from "expo-image-manipulator";
+import type { ImageResult } from "expo-image-manipulator/build/ImageManipulator.types";
 import { setPostData } from "../../actions/post";
 import { setShouldAppearPostBtns } from "../../actions/cameraAndAlbum";
 import { deviceWidth, iPhone11Width } from "../../utilities/dimensions";
@@ -88,6 +90,21 @@ const useAnimation = () => {
   }
 };
 
+const compressImageAsync = (uri: string): Promise<ImageResult> => {
+  return new Promise(async (resolve) => {
+    const actions = [];
+    const manipulatorResult = await ImageManipulator.manipulateAsync(
+      uri,
+      actions,
+      {
+        compress: 0.1,
+      }
+    );
+    console.log("manipulate");
+    resolve(manipulatorResult);
+  });
+};
+
 const navigateToPostScreen = (props: Props) => {
   const { state, routes, navigation } = props;
   const isFocused = state.index === 5;
@@ -124,7 +141,8 @@ const CameraAlbumWrapContainer: FC<Props> = ({ ...props }) => {
     });
 
     if (!result.cancelled) {
-      dispatch(setPostData(result.uri, "camera"));
+      const manipulatorResult = await compressImageAsync(result.uri);
+      dispatch(setPostData(manipulatorResult.uri, "camera"));
       navigateToPostScreen({ state, routes, navigation });
       dispatch(setShouldAppearPostBtns(false));
     }
@@ -147,7 +165,8 @@ const CameraAlbumWrapContainer: FC<Props> = ({ ...props }) => {
     });
 
     if (!result.cancelled) {
-      dispatch(setPostData(result.uri, "album"));
+      const manipulatorResult = await compressImageAsync(result.uri);
+      dispatch(setPostData(manipulatorResult.uri, "album"));
       navigateToPostScreen({ state, routes, navigation });
       dispatch(setShouldAppearPostBtns(false));
     }

--- a/src/containers/molecules/CameraAlbumWrap.tsx
+++ b/src/containers/molecules/CameraAlbumWrap.tsx
@@ -92,12 +92,12 @@ const useAnimation = () => {
 
 const compressImageAsync = (uri: string): Promise<ImageResult> => {
   return new Promise(async (resolve) => {
-    const actions = [];
+    const actions = [{ resize: { width: 600 } }];
     const manipulatorResult = await ImageManipulator.manipulateAsync(
       uri,
       actions,
       {
-        compress: 0.1,
+        compress: 1,
       }
     );
     console.log("manipulate");

--- a/src/containers/molecules/Card.tsx
+++ b/src/containers/molecules/Card.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect, useState } from "react";
 import { Timestamp } from "@google-cloud/firestore";
 import { accountFireStore } from "../../firebase/accountFireStore";
+import { setAspectRatioIntoState } from "../../utilities/imageAspect";
 import Card from "../../components/molecules/Card";
 
 type PhotoDataList = {
@@ -22,6 +23,7 @@ const CardContainer: FC<Props> = ({ ...props }) => {
   const { navigation, data } = props;
   const [postUserName, setPostUserName] = useState<string>("");
   const [isMounted, setIsMounted] = useState<boolean>(false);
+  const [aspectRatio, setAspectRatio] = useState<number>(0);
 
   // ユーザー名の取得
   const getUserName = (uid: string) => {
@@ -41,11 +43,17 @@ const CardContainer: FC<Props> = ({ ...props }) => {
   useEffect(() => {
     setIsMounted(true);
     getUserName(data.uid);
+    setAspectRatioIntoState(data.url, setAspectRatio);
     return () => setIsMounted(false);
   }, [data, isMounted]);
 
   return (
-    <Card navigation={navigation} data={data} postUserName={postUserName} />
+    <Card
+      navigation={navigation}
+      data={data}
+      postUserName={postUserName}
+      aspectRatio={aspectRatio}
+    />
   );
 };
 

--- a/src/containers/molecules/ImageListItem.tsx
+++ b/src/containers/molecules/ImageListItem.tsx
@@ -1,0 +1,52 @@
+import React, { FC, useState, useEffect } from "react";
+import { Timestamp } from "@google-cloud/firestore";
+import { StackNavigationProp } from "@react-navigation/stack";
+import { setAspectRatioIntoState } from "../../utilities/imageAspect";
+import { HomeScreenStackParamList } from "../../screens/HomeScreen";
+import { PickUpScreenStackParamList } from "../../screens/PickUpScreen";
+import { UserScreenStackParamList } from "../../screens/UserScreen";
+import ImageListItem from "../../components/molecules/ImageListItem";
+
+type ImageListScreenNavigationProp = StackNavigationProp<
+  | HomeScreenStackParamList
+  | PickUpScreenStackParamList
+  | UserScreenStackParamList,
+  "detail"
+>;
+
+type PhotoDataList = {
+  photo_id: string;
+  uid: string;
+  create_time: Timestamp;
+  url: string;
+  latitude: number;
+  longitude: number;
+  photogenic_subject: string;
+  img_index: string;
+};
+
+type Props = {
+  item: PhotoDataList;
+  navigation: ImageListScreenNavigationProp;
+  isLast: boolean;
+};
+
+const ImageListItemContainer: FC<Props> = ({ ...props }) => {
+  const { item, navigation, isLast } = props;
+  const [aspectRatio, setAspectRatio] = useState<number>(0);
+
+  useEffect(() => {
+    setAspectRatioIntoState(item.url, setAspectRatio);
+  }, []);
+
+  return (
+    <ImageListItem
+      item={item}
+      navigation={navigation}
+      isLast={isLast}
+      aspectRatio={aspectRatio}
+    />
+  );
+};
+
+export default ImageListItemContainer;

--- a/src/containers/molecules/PhotoDataItem.tsx
+++ b/src/containers/molecules/PhotoDataItem.tsx
@@ -1,0 +1,29 @@
+import React, { FC, useEffect, useState } from "react";
+import { StackNavigationProp } from "@react-navigation/stack";
+import { UserScreenStackParamList } from "../../screens/UserScreen";
+import { setAspectRatioIntoState } from "../../utilities/imageAspect";
+import PhotoDataItem from "../../components/molecules/PhotoDataItem";
+
+type UserScreenNavigationProp = StackNavigationProp<UserScreenStackParamList>;
+
+type Props = {
+  navigation: UserScreenNavigationProp;
+  item: firebase.firestore.DocumentData;
+};
+
+const PhotoDataItemContainer: FC<Props> = ({ navigation, item }) => {
+  const [aspectRatio, setAspectRatio] = useState<number>(0);
+
+  useEffect(() => {
+    setAspectRatioIntoState(item.url, setAspectRatio);
+  }, []);
+  return (
+    <PhotoDataItem
+      navigation={navigation}
+      item={item}
+      aspectRatio={aspectRatio}
+    />
+  );
+};
+
+export default PhotoDataItemContainer;

--- a/src/containers/molecules/PostedPageItems.tsx
+++ b/src/containers/molecules/PostedPageItems.tsx
@@ -8,6 +8,7 @@ import { commentFireStore } from "../../firebase/commentFireStore";
 import { photoFireStore } from "../../firebase/photoFireStore";
 import { notificationFireStore } from "../../firebase/notificationFireStore";
 import { useDisplayTime } from "../../utilities/hooks/date";
+import { setAspectRatioIntoState } from "../../utilities/imageAspect";
 import { upDateFavoriteList } from "../../actions/user";
 import { sendPushFavoriteNotification } from "../../utilities/sendPushNotification";
 import PostedPageItems from "../../components/molecules/PostedPageItems";
@@ -47,6 +48,7 @@ const PostedPageItemsContainer: FC<Props> = ({ ...props }) => {
   const [commentCount, setCommentCount] = useState<number>(0);
   const [favoriteNumber, setFavoriteNumber] = useState<number>(0);
   const [isFavoriteStatus, setIsFavoriteStatus] = useState<boolean>(false);
+  const [aspectRatio, setAspectRatio] = useState<number>(0);
 
   const dispach = useDispatch();
   const date = useDisplayTime(create_time.toMillis());
@@ -58,11 +60,12 @@ const PostedPageItemsContainer: FC<Props> = ({ ...props }) => {
     });
   }, [favoriteList]);
 
-  // コメント数取得
+  // コメント数取得、画像サイズ取得
   useEffect(() => {
     commentFireStore.getCommentDataList(photo_id).then((res) => {
       setCommentCount(res.length);
     });
+    setAspectRatioIntoState(url, setAspectRatio);
   }, []);
 
   // お気に入りチェック
@@ -140,6 +143,7 @@ const PostedPageItemsContainer: FC<Props> = ({ ...props }) => {
       date={date}
       isFavoriteStatus={isFavoriteStatus}
       pressedFavorite={pressedFavorite}
+      aspectRatio={aspectRatio}
     />
   );
 };

--- a/src/containers/organisms/Post.tsx
+++ b/src/containers/organisms/Post.tsx
@@ -5,19 +5,18 @@ import { StyleSheet, BackHandler } from "react-native";
 import type { Dispatch } from "redux";
 import type { NavigationProp } from "@react-navigation/core/lib/typescript/src/types";
 import { useDispatch, useSelector } from "react-redux";
-import { StackNavigationProp } from "@react-navigation/stack";
 import { RootState } from "../../reducers/index";
 import {
   setShouldDisplayBottomNav,
   setShouldNavigate,
 } from "../../actions/bottomNav";
-import { setPhotoListData } from "../../actions/photo";
 import { setAllPhotoListData } from "../../actions/allPhoto";
 import { widthPercentageToDP as wp } from "react-native-responsive-screen";
 import { baseColor } from "../../styles/thema/colors";
 import { postFirebaseStorage } from "../../firebase/postFirebaseStorage";
 import { postFireStore } from "../../firebase/postFireStore";
 import { callingAlert } from "../../utilities/alert";
+import { setAspectRatioIntoState } from "../../utilities/imageAspect";
 import * as Permissions from "expo-permissions";
 import * as Location from "expo-location";
 import firebase from "firebase";
@@ -235,6 +234,7 @@ const PostContainer: FC<Props> = ({ ...props }) => {
     setIsDisable(false);
     setPhotogenicSubject("");
     setLocation({ address: "撮影場所を選択" });
+    setAspectRatioIntoState(uri, setAspectRatio);
     if (type === "camera") {
       (async () => {
         const location = await getNowLocation();
@@ -281,7 +281,10 @@ const PostContainer: FC<Props> = ({ ...props }) => {
       dispatchPhotoData(dispatch, selectedPhotoData, photoData);
       console.log(photoData.photo_id); // 本番では削除
       navigation.navigate("postedImageDetail", {
-        imageData: photoData,
+        imageData: {
+          ...photoData,
+          aspectRatio,
+        },
         shouldHeaderLeftBeCross: true,
       });
       setIsLoading(false);

--- a/src/containers/organisms/PostedImageDetail.tsx
+++ b/src/containers/organisms/PostedImageDetail.tsx
@@ -50,6 +50,7 @@ const PostedImageDetailContainer: FC<Props> = ({ route, navigation }) => {
     longitude,
     photogenic_subject,
     img_index,
+    aspectRatio,
   } = route.params.imageData;
   const shouldHeaderLeftBeCross = route.params.shouldHeaderLeftBeCross;
 
@@ -130,6 +131,7 @@ const PostedImageDetailContainer: FC<Props> = ({ route, navigation }) => {
       focusOnInput={focusOnInput}
       bottomHeight={bottomHeight}
       img_index={img_index}
+      aspectRatio={aspectRatio}
     />
   );
 };

--- a/src/containers/organisms/User.tsx
+++ b/src/containers/organisms/User.tsx
@@ -37,6 +37,7 @@ const ContainerUser: FC<Props> = ({ navigation }) => {
 
   useEffect(() => {
     (() => {
+      setIsMounted(true);
       if (!isMounted) return;
       setMyPhotoDataListCount(myPhotoDataList.length);
     })();
@@ -45,6 +46,7 @@ const ContainerUser: FC<Props> = ({ navigation }) => {
 
   useEffect(() => {
     (() => {
+      setIsMounted(true);
       if (!isMounted) return;
       setFavoriteListCount(favoriteList.length);
     })();

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -20,6 +20,7 @@ export type HomeScreenStackParamList = {
       longitude: number;
       photogenic_subject: string;
       img_index: string;
+      aspectRatio: number;
     };
     shouldHeaderLeftBeCross?: boolean;
   };

--- a/src/screens/PickUpScreen.tsx
+++ b/src/screens/PickUpScreen.tsx
@@ -20,6 +20,7 @@ export type PickUpScreenStackParamList = {
       longitude: number;
       photogenic_subject: string;
       img_index: string;
+      aspectRatio: number;
     };
     shouldHeaderLeftBeCross?: boolean;
   };

--- a/src/screens/UserScreen.tsx
+++ b/src/screens/UserScreen.tsx
@@ -35,6 +35,7 @@ export type UserScreenStackParamList = {
       favoriteNumber: number;
       photogenic_subject: string;
       img_index: string;
+      aspectRatio: number;
     };
     shouldHeaderLeftBeCross?: boolean;
   };

--- a/src/utilities/imageAspect.ts
+++ b/src/utilities/imageAspect.ts
@@ -1,0 +1,18 @@
+import React from "react";
+import { Image } from "react-native";
+
+export const setAspectRatioIntoState = (
+  uri: string,
+  set: React.Dispatch<React.SetStateAction<number>>
+) => {
+  Image.getSize(
+    uri,
+    (width, height) => {
+      const aspectRatio = height / width;
+      set(aspectRatio);
+    },
+    (error) => {
+      set(0);
+    }
+  );
+};


### PR DESCRIPTION
## 目的
- ユーザーページで投稿といいねが表示されないバグの解消
- 画像サイズの削減
- 投稿詳細ページに遷移した際に、画像が表示前と表示後でサイズが変わってしまう問題の解決

## 実装の概要
### 画像サイズの削減
`ImageManipulator.manipulateAsync`を使用して画像圧縮を行った。
しかし、compressを0.1に指定しても画質が悪くなる上に**17%程度の圧縮率**(`6MB`が`1MB`になる程度)だった。
そのため、画質が悪くなる問題も考慮して画像圧縮処理を削除し、画像サイズを変更する処理を追加した。
画像投稿時にwidthを600に縮小し、heightもそれに合わせて自動で小さくなるようにしたところ、
3024*4032で7.14MBの画像を圧縮なしで投稿すると、600*800の375.58KBになった

### 投稿詳細ページに遷移した際に、画像が表示前と表示後でサイズが変わってしまう問題の解決
以前は投稿詳細画面に遷移した瞬間に画像サイズを取得していたため、表示前と表示後でサイズが変わってしまうという問題が起きていた。
遷移前に予め画像サイズを取得して`props`で渡すやり方でそれを解決した。

## 問題点
通知から遷移する際にエラーが起きてしまう。
まだ解決できていないので後で修正する