### PR TITLE
Fix: 細かな箇所の修正

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -24,6 +24,10 @@ if (Platform.OS === "ios") {
   YellowBox.ignoreWarnings(["Setting a timer"]);
 }
 
+YellowBox.ignoreWarnings([
+  "Non-serializable values were found in the navigation state",
+]);
+
 const store = createStore(rootReducer);
 
 const App: FC = () => {

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -32,6 +32,48 @@ type Props = {
   setContainerAspect: React.Dispatch<React.SetStateAction<Aspect>>;
 };
 
+const getPreviewStyle = (
+  fullDisplayHeight: number,
+  containerAspect: Aspect,
+  aspectRatio: number
+): { previewImgAspect: Aspect; previewStyle: { wrap: Object } } => {
+  if (fullDisplayHeight < containerAspect.height) {
+    const previewImgAspect = {
+      width: deviceWidth,
+      height: fullDisplayHeight,
+    };
+
+    const previewStyle = StyleSheet.create({
+      wrap: {
+        zIndex: 1,
+        position: "absolute",
+        top: (containerAspect.height - fullDisplayHeight) / 2,
+        left: 0,
+        backgroundColor: baseColor.base,
+      },
+    });
+
+    return { previewImgAspect, previewStyle };
+  } else {
+    const previewImgAspect = {
+      width: containerAspect.height / aspectRatio,
+      height: containerAspect.height,
+    };
+
+    const previewStyle = StyleSheet.create({
+      wrap: {
+        zIndex: 1,
+        position: "absolute",
+        top: 0,
+        left: (containerAspect.width - previewImgAspect.width) / 2,
+        backgroundColor: baseColor.base,
+      },
+    });
+
+    return { previewImgAspect, previewStyle };
+  }
+};
+
 const Post: FC<Props> = ({ ...props }) => {
   const {
     uri,
@@ -55,33 +97,12 @@ const Post: FC<Props> = ({ ...props }) => {
       : { color: baseColor.text };
 
   const aspectRatio = imageLength.height / imageLength.width;
-
   const fullDisplayHeight = deviceWidth * aspectRatio;
-  const isImageHeightSmall = fullDisplayHeight < containerAspect.height;
-  const previewImgAspect = isImageHeightSmall
-    ? {
-        width: deviceWidth,
-        height: fullDisplayHeight,
-      }
-    : {
-        width: containerAspect.height / aspectRatio,
-        height: containerAspect.height,
-      };
-
-  const previewStyle = StyleSheet.create({
-    wrap: {
-      zIndex: 1,
-      position: "absolute",
-      top: isImageHeightSmall
-        ? (containerAspect.height - fullDisplayHeight) / 2
-        : 0,
-      left: isImageHeightSmall
-        ? 0
-        : (containerAspect.width - previewImgAspect.width) / 2,
-      backgroundColor: baseColor.base,
-    },
-  });
-
+  const { previewImgAspect, previewStyle } = getPreviewStyle(
+    fullDisplayHeight,
+    containerAspect,
+    aspectRatio
+  );
   const heightToDisplay =
     fullDisplayHeight < deviceWidth ? fullDisplayHeight : deviceWidth;
 

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -19,7 +19,7 @@ type Aspect = {
 type Props = {
   uri: string;
   address: string;
-  aspectRatio: number;
+  imageLength: Aspect;
   scrollViewRef: React.MutableRefObject<ScrollView | null>;
   setSpaceHeight: React.Dispatch<React.SetStateAction<number>>;
   handleContentSizeChange: (width: number, height: number) => void;
@@ -36,7 +36,7 @@ const Post: FC<Props> = ({ ...props }) => {
   const {
     uri,
     address,
-    aspectRatio,
+    imageLength,
     scrollViewRef,
     setSpaceHeight,
     handleContentSizeChange,
@@ -54,13 +54,14 @@ const Post: FC<Props> = ({ ...props }) => {
       ? { color: utilityColor.placeholderText }
       : { color: baseColor.text };
 
-  const height = deviceWidth * aspectRatio;
+  const aspectRatio = imageLength.height / imageLength.width;
 
-  const isImageHeightSmall = height < containerAspect.height;
-  const imageAspect = isImageHeightSmall
+  const fullDisplayHeight = deviceWidth * aspectRatio;
+  const isImageHeightSmall = fullDisplayHeight < containerAspect.height;
+  const previewImgAspect = isImageHeightSmall
     ? {
         width: deviceWidth,
-        height: height,
+        height: fullDisplayHeight,
       }
     : {
         width: containerAspect.height / aspectRatio,
@@ -71,13 +72,18 @@ const Post: FC<Props> = ({ ...props }) => {
     wrap: {
       zIndex: 1,
       position: "absolute",
-      top: isImageHeightSmall ? (containerAspect.height - height) / 2 : 0,
+      top: isImageHeightSmall
+        ? (containerAspect.height - fullDisplayHeight) / 2
+        : 0,
       left: isImageHeightSmall
         ? 0
-        : (containerAspect.width - imageAspect.width) / 2,
+        : (containerAspect.width - previewImgAspect.width) / 2,
       backgroundColor: baseColor.base,
     },
   });
+
+  const heightToDisplay =
+    fullDisplayHeight < deviceWidth ? fullDisplayHeight : deviceWidth;
 
   return (
     <>
@@ -94,8 +100,8 @@ const Post: FC<Props> = ({ ...props }) => {
           >
             <Image
               style={{
-                width: imageAspect.width,
-                height: imageAspect.height,
+                width: previewImgAspect.width,
+                height: previewImgAspect.height,
               }}
               source={{ uri }}
             />
@@ -122,7 +128,7 @@ const Post: FC<Props> = ({ ...props }) => {
             <TouchableOpacity onPress={() => setShouldShowPreview(true)}>
               <Image
                 style={[
-                  { width: deviceWidth, height: deviceWidth },
+                  { width: deviceWidth, height: heightToDisplay },
                   styles.image,
                 ]}
                 source={{ uri }}

--- a/src/containers/molecules/CameraAlbumWrap.tsx
+++ b/src/containers/molecules/CameraAlbumWrap.tsx
@@ -92,12 +92,12 @@ const useAnimation = () => {
 
 const compressImageAsync = (uri: string): Promise<ImageResult> => {
   return new Promise(async (resolve) => {
-    const actions = [{ resize: { width: 600 } }];
+    const actions = [{ resize: { width: 800 } }];
     const manipulatorResult = await ImageManipulator.manipulateAsync(
       uri,
       actions,
       {
-        compress: 1,
+        compress: 0.6,
       }
     );
     resolve(manipulatorResult);

--- a/src/containers/molecules/Card.tsx
+++ b/src/containers/molecules/Card.tsx
@@ -27,9 +27,6 @@ const CardContainer: FC<Props> = ({ ...props }) => {
 
   // ユーザー名の取得
   const getUserName = (uid: string) => {
-    // isMounted === trueの時はuseState関連の処理を行わないようにする
-    // "Can only update a mounted or mounting component"Warningエラーを起こさないために必要
-    if (!isMounted) return;
     accountFireStore
       .getUserName(uid)
       .then((res: React.SetStateAction<string>) => {
@@ -42,8 +39,13 @@ const CardContainer: FC<Props> = ({ ...props }) => {
 
   useEffect(() => {
     setIsMounted(true);
-    getUserName(data.uid);
-    setAspectRatioIntoState(data.url, setAspectRatio);
+    (() => {
+      // isMounted === trueの時はuseState関連の処理を行わないようにする
+      // "Can only update a mounted or mounting component"Warningエラーを起こさないために必要
+      if (!isMounted) return;
+      getUserName(data.uid);
+      setAspectRatioIntoState(data.url, setAspectRatio);
+    })();
     return () => setIsMounted(false);
   }, [data, isMounted]);
 

--- a/src/containers/organisms/Post.tsx
+++ b/src/containers/organisms/Post.tsx
@@ -16,7 +16,7 @@ import { baseColor } from "../../styles/thema/colors";
 import { postFirebaseStorage } from "../../firebase/postFirebaseStorage";
 import { postFireStore } from "../../firebase/postFireStore";
 import { callingAlert } from "../../utilities/alert";
-import { setAspectRatioIntoState } from "../../utilities/imageAspect";
+import { setImageLengthIntoState } from "../../utilities/imageAspect";
 import * as Permissions from "expo-permissions";
 import * as Location from "expo-location";
 import firebase from "firebase";
@@ -183,7 +183,7 @@ const PostContainer: FC<Props> = ({ ...props }) => {
   const [isDisabled, setIsDisable] = useState<boolean>(false);
   const [isPressing, setIsPressing] = useState<boolean>(false);
   const [spaceHeight, setSpaceHeight] = useState(0);
-  const [aspectRatio, setAspectRatio] = useState<number>(0);
+  const [imageLength, setImageLength] = useState({ width: 0, height: 0 });
   const [shouldShowPreview, setShouldShowPreview] = useState<boolean>(false);
   const [containerAspect, setContainerAspect] = useState({
     width: 1,
@@ -234,7 +234,7 @@ const PostContainer: FC<Props> = ({ ...props }) => {
     setIsDisable(false);
     setPhotogenicSubject("");
     setLocation({ address: "撮影場所を選択" });
-    setAspectRatioIntoState(uri, setAspectRatio);
+    setImageLengthIntoState(uri, setImageLength);
     if (type === "camera") {
       (async () => {
         const location = await getNowLocation();
@@ -283,7 +283,7 @@ const PostContainer: FC<Props> = ({ ...props }) => {
       navigation.navigate("postedImageDetail", {
         imageData: {
           ...photoData,
-          aspectRatio,
+          aspectRatio: imageLength.height / imageLength.width,
         },
         shouldHeaderLeftBeCross: true,
       });
@@ -335,7 +335,7 @@ const PostContainer: FC<Props> = ({ ...props }) => {
       <Post
         uri={uri}
         address={location.address}
-        aspectRatio={aspectRatio}
+        imageLength={imageLength}
         scrollViewRef={scrollViewRef}
         setSpaceHeight={setSpaceHeight}
         handleContentSizeChange={handleContentSizeChange}

--- a/src/utilities/imageAspect.ts
+++ b/src/utilities/imageAspect.ts
@@ -16,3 +16,18 @@ export const setAspectRatioIntoState = (
     }
   );
 };
+
+export const setImageLengthIntoState = (
+  uri: string,
+  set: React.Dispatch<React.SetStateAction<{ width: number; height: number }>>
+) => {
+  Image.getSize(
+    uri,
+    (width, height) => {
+      set({ width, height });
+    },
+    (error) => {
+      set({ width: 0, height: 0 });
+    }
+  );
+};


### PR DESCRIPTION
## 実装の概要
- マップ画面で発生するエラーを非表示にした
- `Non-serializable values were found in the navigation state`の警告を非表示にした
  - 調べてもエラー自体を非表示にするしか方法がなかったため
- 投稿画面にて、横長の画像は正方形ではなく原寸比で表示するようにした
  - 縦長の画像はこれまで通り正方形で表示