### PR TITLE
広告をmap上部に追加

### DIFF
--- a/src/components/molecules/AdModCard.tsx
+++ b/src/components/molecules/AdModCard.tsx
@@ -1,0 +1,63 @@
+// import React, { FC } from "react";
+// import {
+//   View,
+//   StyleSheet,
+//   Text,
+//   Image,
+//   TouchableOpacity,
+//   Platform,
+//   PlatformIOSStatic,
+// } from "react-native";
+// import { Timestamp } from "@google-cloud/firestore";
+// import { deviceWidth } from "../../utilities/dimensions";
+// import { baseColor } from "../../styles/thema/colors";
+// import { AdMobBanner } from "expo-ads-admob";
+
+// const CARD_HEIGHT = 220;
+// const CARD_WIDTH = deviceWidth * 0.8;
+// const bannerError = () => {
+//   console.log("Ad Fail error");
+// };
+// const AdModCard: FC = () => {
+//   return (
+//     <View style={styles.card}>
+//       <AdMobBanner
+//         adUnitID={
+//           __DEV__
+//             ? "ca-app-pub-3940256099942544/6300978111" // テスト広告
+//             : Platform.select({
+//                 ios: "広告ユニットID", // iOS
+//                 android: "広告ユニットID", // android
+//               })
+//         }
+//         onDidFailToReceiveAdWithError={bannerError}
+//         servePersonalizedAds
+//         bannerSize="mediumRectangle"
+//         // 'banner' | 'largeBanner' | 'mediumRectangle' | 'fullBanner' | 'leaderboard' | 'smartBannerPortrait' | 'smartBannerLandscape';
+//       />
+//     </View>
+//   );
+// };
+
+// const styles = StyleSheet.create({
+//   card: {
+//     alignItems: "center",
+//     elevation: 2,
+//     backgroundColor: baseColor.darkNavy,
+//     borderColor: "rgba(170, 170, 170, 0.6)",
+//     borderWidth: 0.5,
+//     borderTopLeftRadius: 5,
+//     borderTopRightRadius: 5,
+//     borderBottomLeftRadius: 5,
+//     borderBottomRightRadius: 5,
+//     marginHorizontal: 10,
+//     shadowColor: "#000",
+//     shadowRadius: 5,
+//     shadowOpacity: 0.3,
+//     height: CARD_HEIGHT - 50,
+//     width: CARD_WIDTH,
+//     overflow: "hidden",
+//   },
+// });
+
+// export default AdModCard;

--- a/src/components/organisms/Home.tsx
+++ b/src/components/organisms/Home.tsx
@@ -20,6 +20,7 @@ import OriginMarker from "../atoms/OriginMarker";
 import geohash from "ngeohash";
 import Spinner from "react-native-loading-spinner-overlay";
 import Card from "../../containers/molecules/Card";
+import { AdMobBanner } from "expo-ads-admob";
 
 type HomeScreenNavigationProp = StackNavigationProp<
   HomeScreenStackParamList,
@@ -50,6 +51,10 @@ const { width, height } = Dimensions.get("window");
 const CARD_HEIGHT = 220;
 const CARD_WIDTH = width * 0.8;
 const SPACING_FOR_CARD_INSET = width * 0.1 - 10;
+
+const bannerError = () => {
+  console.log("Ad Fail error");
+};
 
 let mapIndex = 0;
 let regionTimeout;
@@ -350,6 +355,23 @@ const Home: FC<Props> = ({ ...props }) => {
           />
         </>
       )}
+
+      <View style={styles.admod}>
+        <AdMobBanner
+          adUnitID={
+            __DEV__
+              ? "ca-app-pub-3940256099942544/6300978111" // テスト広告
+              : Platform.select({
+                  ios: "広告ユニットID", // iOS
+                  android: "広告ユニットID", // android
+                })
+          }
+          onDidFailToReceiveAdWithError={bannerError}
+          servePersonalizedAds
+          bannerSize="smartBannerPortrait"
+          // 'banner' | 'largeBanner' | 'mediumRectangle' | 'fullBanner' | 'leaderboard' | 'smartBannerPortrait' | 'smartBannerLandscape';
+        />
+      </View>
     </Container>
   );
 };
@@ -360,6 +382,10 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     paddingVertical: 10,
+  },
+  admod: {
+    alignItems: "center",
+    width: "100%",
   },
 });
 export default Home;


### PR DESCRIPTION
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-09-27 at 19 04 02](https://user-images.githubusercontent.com/57976204/94362153-471c7680-00f4-11eb-8586-007c3bced5d4.png)
上記の様にmap画面の最上部に広告を追加
またカードレイアウト用の広告を作ったが一旦コメントアウト←（サイズを合わせる手段があれば追加したい）